### PR TITLE
Do not duplicate case/choice by an explicit `type`

### DIFF
--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -451,35 +451,6 @@ module ietf-optical-impairment-topology {
     /*
    * Identities
    */
-  identity type-element {
-    description
-      "Base identity for element type";
-  }
-
-  identity Fiber {
-    base type-element;
-    description
-      "Fiber element";
-  }
-
-  identity Roadm {
-    base type-element;
-    description
-      "Roadm element";
-  }
-
-  identity Edfa {
-    base type-element;
-    description
-      "Edfa element";
-  }
-
-  identity Concentratedloss {
-    base type-element;
-    description
-      "Concentratedloss element";
-  }
-  
   identity type-power-mode {
     description
       "power equalization mode used within the OMS and its elements";
@@ -811,28 +782,18 @@ module ietf-optical-impairment-topology {
           description
             "unique id of the element if it exists";
         }
-        leaf type {
-          type identityref {
-             base type-element;
-          }
-      mandatory true;    
-      description "element type";       
-        }
         
         container element {
           description "element of the list of elements of the OMS";
           choice element {
         description "OMS element type";
             case amplifier {
- /*             when "type = 'Edfa'"; */
               uses amplifier-params ;
             }
             case fiber {
-/*              when "type = 'Fiber'"; */
               uses fiber-params ;
             }
             case concentratedloss {
-/*             when "type = 'Concentratedloss'"; */
               uses concentratedloss-params ;
             }            
           }


### PR DESCRIPTION
Within the `OMS-elements` list, the model supports multiple "types" or "classes" of elements -- amplifiers, fiber spans and attenuators, and possible ROADMs in future. The distinction on "what type of an element" is currently modeled via two means:

- the `type` leaf which is an `identityref` to a `type-element` identity,
- the `choice` YANG statement and its inner container.

This is redundant, and possibly quite confusing (see the commented-out `when` stanzas, for example).

YANG's `choice` and `case` statements provide adequate functionality here because they guarantee that exactly one possibility gets selected.

fixes #21

(I'm deliberately not updating the `tree` diagram because it looks like it's outdated now.)