### PR TITLE
improve element naming

### DIFF
--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -21,7 +21,7 @@ module: ietf-optical-impairment-topology
        |     +--ro OTSi-ref?    leafref
        +--ro OMS-elements* [elt-index]
           +--ro elt-index                 uint16
-          +--ro uid?                      string
+          +--ro oms-element-uid?          string
           +--ro (element)
              +--:(amplifier)
              |  +--ro amplifier

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -1106,7 +1106,7 @@ module ietf-optical-impairment-topology {
             (whether it's a Fiber, an EDFA or a
 Concentratedloss)";
         }
-        leaf uid {
+        leaf oms-element-uid {
           type string;
           description
             "unique id of the element if it exists";


### PR DESCRIPTION
using only uid and type in an implementation can lead to confusion,
I suggest to add the context of these attributes in their names:

oms-element-uid instead of just uid

Signed-off-by: EstherLerouzic <esther.lerouzic@orange.com>