### PR TITLE
draft-ietf-ccamp-optical-impairment-topology-yang.xml for IETF 112 submission

### DIFF
--- a/I-D_in_xml/draft-ietf-ccamp-optical-impairment-topology-yang-08.txt
+++ b/I-D_in_xml/draft-ietf-ccamp-optical-impairment-topology-yang-08.txt
@@ -231,8 +231,8 @@ Internet-Draft    Opt. Impairment-Aware Topo YANG Model     October 2021
    +-------------+--------------------------+--------------------------+
    | optical-    | ietf-optical-impairment- | [RFCXXXX]                |
    | imp-topo    | topology                 |                          |
-   | layer0-type | ietf-layer0-types        | [I-D.ietf-ccamp-layer0-t |
-   | s           |                          | ypes]                    |
+   | layer0-type | ietf-layer0-types        | [RFC9093]                |
+   | s           |                          |                          |
    | l0-types-   | ietf-layer0-types-ext    | [I-D.ietf-ccamp-layer0-t |
    | ext         |                          | ypes-ext]                |
    | nw          | ietf-network             | [RFC8345]                |
@@ -3450,22 +3450,22 @@ Internet-Draft    Opt. Impairment-Aware Topo YANG Model     October 2021
               DOI 10.17487/RFC8453, August 2018,
               <https://www.rfc-editor.org/info/rfc8453>.
 
-   [I-D.ietf-ccamp-wson-yang]
-              Zheng, H., Lee, Y., Guo, A., Lopez, V., and D. King, "A
-              YANG Data Model for Wavelength Switched Optical Networks
-              (WSONs)", draft-ietf-ccamp-wson-yang-28 (work in
-              progress), December 2020.
+   [RFC9093]  Zheng, H., Lee, Y., Guo, A., Lopez, V., and D. King, "A
+              YANG Data Model for Layer 0 Types", RFC 9093,
+              DOI 10.17487/RFC9093, August 2021,
+              <https://www.rfc-editor.org/info/rfc9093>.
 
-   [I-D.ietf-ccamp-layer0-types]
-              Zheng, H., Lee, Y., Guo, A., Lopez, V., and D. King, "A
-              YANG Data Model for Layer 0 Types", draft-ietf-ccamp-
-              layer0-types-09 (work in progress), December 2020.
+   [RFC9094]  Zheng, H., Lee, Y., Guo, A., Lopez, V., and D. King, "A
+              YANG Data Model for Wavelength Switched Optical Networks
+              (WSONs)", RFC 9094, DOI 10.17487/RFC9094, August 2021,
+              <https://www.rfc-editor.org/info/rfc9094>.
 
    [I-D.ietf-ccamp-layer0-types-ext]
               Beller, D., Belotti, S., Zheng, H., Busi, I., and E. L.
               Rouzic, "A YANG Data Model for Layer 0 Types - Revision
               2", draft-ietf-ccamp-layer0-types-ext-00 (work in
               progress), August 2021.
+
 
 
 

--- a/I-D_in_xml/draft-ietf-ccamp-optical-impairment-topology-yang.xml
+++ b/I-D_in_xml/draft-ietf-ccamp-optical-impairment-topology-yang.xml
@@ -15,8 +15,8 @@
 <!ENTITY RFC8345 SYSTEM "https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8345.xml">
 <!ENTITY RFC8453 SYSTEM "https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8453.xml">
 <!ENTITY RFC8795 SYSTEM "https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8795.xml">
-<!ENTITY I-D.ietf-ccamp-wson-yang SYSTEM "https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-ccamp-wson-yang.xml">
-<!ENTITY I-D.ietf-ccamp-layer0-types SYSTEM "https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-ccamp-layer0-types.xml">
+<!ENTITY RFC9093 SYSTEM "https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9093.xml">
+<!ENTITY RFC9094 SYSTEM "https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9094.xml">
 <!ENTITY I-D.ietf-ccamp-layer0-types-ext SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.draft-ietf-ccamp-layer0-types-ext.xml">
 <!ENTITY I-D.ietf-ccamp-dwdm-if-param-yang SYSTEM "https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-ccamp-dwdm-if-param-yang.xml">
 <!ENTITY I-D.ietf-teas-te-topo-and-tunnel-modeling SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.draft-ietf-teas-te-topo-and-tunnel-modeling.xml">
@@ -216,7 +216,7 @@
    <c>[RFCXXXX]</c>
    <c>layer0-types</c>
    <c>ietf-layer0-types</c>
-   <c><xref target="I-D.ietf-ccamp-layer0-types"/></c> 
+   <c><xref target="RFC9093"/></c> 
    <c>l0-types-ext</c>
    <c>ietf-layer0-types-ext</c>
    <c><xref target="I-D.ietf-ccamp-layer0-types-ext"/></c>
@@ -3119,8 +3119,8 @@ reference: RFC XXXX (TDB)
   &RFC8342;
   &RFC8345;
   &RFC8453;
-  &I-D.ietf-ccamp-wson-yang;
-  &I-D.ietf-ccamp-layer0-types;
+  &RFC9093;
+  &RFC9094;
   &I-D.ietf-ccamp-layer0-types-ext;
   &I-D.ietf-ccamp-dwdm-if-param-yang;
   &I-D.ietf-teas-te-topo-and-tunnel-modeling;


### PR DESCRIPTION
draft-ietf-ccamp-optical-impairment-topology-yang.xml for IETF 112 submission --> draft-ietf-ccamp-optical-impairment-topology-yang-08.txt

This revision of the I-D includes the latest YANG model update - see #93.

Open issues #70 , #77 , and #89 are addressed and resolved.