### PR TITLE
Updated YANG model for IETF 113

### DIFF
--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -7,10 +7,10 @@ module: ietf-optical-impairment-topology
        +--ro otsi-group-id    string
        +--ro otsi* [otsi-carrier-id]
           +--ro otsi-carrier-id           uint16
-          +--ro otsi-carrier-frequency?   frequency-thz
-          +--ro tx-channel-power?         dbm-t
-          +--ro rx-channel-power?         dbm-t
-          +--ro rx-total-power?           dbm-t
+          +--ro otsi-carrier-frequency?   union
+          +--ro tx-channel-power?         union
+          +--ro rx-channel-power?         union
+          +--ro rx-total-power?           union
   augment /nw:networks/nw:network/nw:node:
     +--ro transponder* [transponder-id]
     |  +--ro transponder-id                   uint32
@@ -50,24 +50,26 @@ module: ietf-optical-impairment-topology
     |     |              |          -> ../../../mode-id
     |     |              +--ro line-coding-bitrate?
     |     |              |       identityref
+    |     |              +--ro bitrate?
+    |     |              |       uint16
     |     |              +--ro max-polarization-mode-dispersion?
     |     |              |       decimal64
     |     |              +--ro max-chromatic-dispersion?
     |     |              |       decimal64
     |     |              +--ro chromatic-and-polarization-dispersion-penalty* []
     |     |              |  +--ro chromatic-dispersion
-    |     |              |  |       decimal64
+    |     |              |  |       union
     |     |              |  +--ro polarization-mode-dispersion
-    |     |              |  |       decimal64
+    |     |              |  |       union
     |     |              |  +--ro penalty
-    |     |              |          decimal64
+    |     |              |          union
     |     |              +--ro max-diff-group-delay?
     |     |              |       int32
     |     |              +--ro max-polarization-dependent-loss-penalty* []
     |     |              |  +--ro max-polarization-dependent-loss
-    |     |              |  |       decimal64
+    |     |              |  |       power-in-db-or-null
     |     |              |  +--ro penalty
-    |     |              |          uint8
+    |     |              |          union
     |     |              +--ro available-modulation-type?
     |     |              |       identityref
     |     |              +--ro min-OSNR?
@@ -124,9 +126,10 @@ module: ietf-optical-impairment-topology
        +--ro equalization-mode                       identityref
        +--ro (power-param)?
        |  +--:(channel-power)
-       |  |  +--ro nominal-carrier-power?            decimal64
+       |  |  +--ro nominal-carrier-power?
+       |  |          l0-types-ext:power-in-dbm-or-null
        |  +--:(power-spectral-density)
-       |     +--ro nominal-power-spectral-density?   decimal64
+       |     +--ro nominal-power-spectral-density?   union
        +--ro media-channel-group* [i]
        |  +--ro i                 int16
        |  +--ro media-channels* [flexi-n]
@@ -135,10 +138,11 @@ module: ietf-optical-impairment-topology
        |     +--ro otsi-group-ref?
        |     |       -> /nw:networks/network/otsi-group/otsi-group-id
        |     +--ro otsi-ref*         leafref
-       |     +--ro delta-power?      decimal64
+       |     +--ro delta-power?
+       |             l0-types-ext:power-in-dbm-or-null
        +--ro OMS-elements* [elt-index]
           +--ro elt-index                 uint16
-          +--ro oms-element-uid?          string
+          +--ro oms-element-uid?          union
           +--ro reverse-element-ref
           |  +--ro link-ref?
           |  |       -> ../../../../../../../nt:link/link-id
@@ -159,32 +163,47 @@ module: ietf-optical-impairment-topology
              |           |  +--ro lower-frequency    frequency-thz
              |           |  +--ro upper-frequency    frequency-thz
              |           +--ro actual-gain
-             |           |       decimal64
+             |           |       l0-types-ext:power-in-db-or-null
              |           +--ro tilt-target
-             |           |       decimal64
+             |           |       l0-types-ext:decimal-2-digits-or-null
              |           +--ro out-voa
-             |           |       decimal64
+             |           |       l0-types-ext:power-in-db-or-null
              |           +--ro in-voa
-             |           |       decimal64
+             |           |       l0-types-ext:power-in-db-or-null
+             |           +--ro total-output-power
+             |           |       l0-types-ext:power-in-db-or-null
              |           +--ro (power-param)?
-             |              +--:(channel-power)
-             |              |  +--ro nominal-carrier-power?
-             |              |          decimal64
-             |              +--:(power-spectral-density)
-             |                 +--ro nominal-power-spectral-density?
-             |                         decimal64
+             |           |  +--:(channel-power)
+             |           |  |  +--ro nominal-carrier-power?
+             |           |  |          l0-types-ext:power-in-dbm-or-null
+             |           |  +--:(power-spectral-density)
+             |           |     +--ro nominal-power-spectral-density?
+             |           |             union
+             |           +--ro raman-direction?
+             |           |       enumeration
+             |           +--ro raman-pump* []
+             |              +--ro frequency?
+             |              |       l0-types-ext:frequency-thz
+             |              +--ro power?
+             |                      l0-types-ext:decimal-2-digits-or-null
              +--:(fiber)
              |  +--ro fiber
              |     +--ro type-variety    string
-             |     +--ro length          decimal64
-             |     +--ro loss-coef       decimal64
-             |     +--ro total-loss      decimal64
-             |     +--ro pmd?            decimal64
-             |     +--ro conn-in?        decimal64
-             |     +--ro conn-out?       decimal64
+             |     +--ro length
+             |     |       l0-types-ext:decimal-2-digits-or-null
+             |     +--ro loss-coef
+             |     |       l0-types-ext:decimal-2-digits-or-null
+             |     +--ro total-loss
+             |     |       l0-types-ext:power-in-db-or-null
+             |     +--ro pmd?
+             |     |       l0-types-ext:decimal-2-digits-or-null
+             |     +--ro conn-in?
+             |     |       l0-types-ext:power-in-db-or-null
+             |     +--ro conn-out?
+             |             l0-types-ext:power-in-db-or-null
              +--:(concentratedloss)
                 +--ro concentratedloss
-                   +--ro loss    decimal64
+                   +--ro loss    l0-types-ext:power-in-db-or-null
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:tunnel-termination-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
@@ -205,41 +224,58 @@ module: ietf-optical-impairment-topology
           |     +--ro frequency-range
           |     |  +--ro lower-frequency    frequency-thz
           |     |  +--ro upper-frequency    frequency-thz
-          |     +--ro roadm-pmd?                decimal64
-          |     +--ro roadm-cd?                 decimal64
-          |     +--ro roadm-pdl?                decimal64
-          |     +--ro roadm-inband-crosstalk?   decimal64
-          |     +--ro roadm-maxloss?            decimal64
+          |     +--ro roadm-pmd?                union
+          |     +--ro roadm-cd?                 union
+          |     +--ro roadm-pdl?
+          |     |       l0-types-ext:power-in-db-or-null
+          |     +--ro roadm-inband-crosstalk?
+          |     |       l0-types-ext:power-in-db-or-null
+          |     +--ro roadm-maxloss?
+          |             l0-types-ext:power-in-db-or-null
           +--:(roadm-add-path)
           |  +--ro roadm-add-path* []
           |     +--ro frequency-range
           |     |  +--ro lower-frequency    frequency-thz
           |     |  +--ro upper-frequency    frequency-thz
-          |     +--ro roadm-pmd?                decimal64
-          |     +--ro roadm-cd?                 decimal64
-          |     +--ro roadm-pdl?                decimal64
-          |     +--ro roadm-inband-crosstalk?   decimal64
-          |     +--ro roadm-maxloss?            decimal64
-          |     +--ro roadm-pmax?               decimal64
-          |     +--ro roadm-osnr?               l0-types-ext:snr
-          |     +--ro roadm-noise-figure?       decimal64
+          |     +--ro roadm-pmd?                union
+          |     +--ro roadm-cd?                 union
+          |     +--ro roadm-pdl?
+          |     |       l0-types-ext:power-in-db-or-null
+          |     +--ro roadm-inband-crosstalk?
+          |     |       l0-types-ext:power-in-db-or-null
+          |     +--ro roadm-maxloss?
+          |     |       l0-types-ext:power-in-db-or-null
+          |     +--ro roadm-pmax?
+          |     |       l0-types-ext:power-in-dbm-or-null
+          |     +--ro roadm-osnr?
+          |     |       l0-types-ext:snr-or-null
+          |     +--ro roadm-noise-figure?       union
           +--:(roadm-drop-path)
              +--ro roadm-drop-path* []
                 +--ro frequency-range
                 |  +--ro lower-frequency    frequency-thz
                 |  +--ro upper-frequency    frequency-thz
-                +--ro roadm-pmd?                decimal64
-                +--ro roadm-cd?                 decimal64
-                +--ro roadm-pdl?                decimal64
-                +--ro roadm-inband-crosstalk?   decimal64
-                +--ro roadm-maxloss?            decimal64
-                +--ro roadm-minloss?            decimal64
-                +--ro roadm-typloss?            decimal64
-                +--ro roadm-pmin?               decimal64
-                +--ro roadm-pmax?               decimal64
-                +--ro roadm-ptyp?               decimal64
-                +--ro roadm-osnr?               l0-types-ext:snr
-                +--ro roadm-noise-figure?       decimal64
+                +--ro roadm-pmd?                union
+                +--ro roadm-cd?                 union
+                +--ro roadm-pdl?
+                |       l0-types-ext:power-in-db-or-null
+                +--ro roadm-inband-crosstalk?
+                |       l0-types-ext:power-in-db-or-null
+                +--ro roadm-maxloss?
+                |       l0-types-ext:power-in-db-or-null
+                +--ro roadm-minloss?
+                |       l0-types-ext:power-in-db-or-null
+                +--ro roadm-typloss?
+                |       l0-types-ext:power-in-db-or-null
+                +--ro roadm-pmin?
+                |       l0-types-ext:power-in-dbm-or-null
+                +--ro roadm-pmax?
+                |       l0-types-ext:power-in-dbm-or-null
+                +--ro roadm-ptyp?
+                |       l0-types-ext:power-in-dbm-or-null
+                +--ro roadm-osnr?
+                |       l0-types-ext:snr-or-null
+                +--ro roadm-noise-figure?       union
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:information-source-entry/tet:connectivity-matrices:
     +--ro roadm-path-impairments?   leafref

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -122,12 +122,12 @@ module: ietf-optical-impairment-topology
   augment /nw:networks/nw:network/nt:link/tet:te
             /tet:te-link-attributes:
     +--ro OMS-attributes
-       +--ro generalized-snr?                        l0-types-ext:snr
+       +--ro generalized-snr?                        l0-types:snr
        +--ro equalization-mode                       identityref
        +--ro (power-param)?
        |  +--:(channel-power)
        |  |  +--ro nominal-carrier-power?
-       |  |          l0-types-ext:power-in-dbm-or-null
+       |  |          l0-types:power-in-dbm-or-null
        |  +--:(power-spectral-density)
        |     +--ro nominal-power-spectral-density?   union
        +--ro media-channel-group* [i]
@@ -138,8 +138,7 @@ module: ietf-optical-impairment-topology
        |     +--ro otsi-group-ref?
        |     |       -> /nw:networks/network/otsi-group/otsi-group-id
        |     +--ro otsi-ref*         leafref
-       |     +--ro delta-power?
-       |             l0-types-ext:power-in-dbm-or-null
+       |     +--ro delta-power?      l0-types:power-in-dbm-or-null
        +--ro OMS-elements* [elt-index]
           +--ro elt-index                 uint16
           +--ro oms-element-uid?          union
@@ -163,47 +162,43 @@ module: ietf-optical-impairment-topology
              |           |  +--ro lower-frequency    frequency-thz
              |           |  +--ro upper-frequency    frequency-thz
              |           +--ro actual-gain
-             |           |       l0-types-ext:power-in-db-or-null
+             |           |       l0-types:power-in-db-or-null
              |           +--ro tilt-target
-             |           |       l0-types-ext:decimal-2-digits-or-null
+             |           |       l0-types:decimal-2-digits-or-null
              |           +--ro out-voa
-             |           |       l0-types-ext:power-in-db-or-null
+             |           |       l0-types:power-in-db-or-null
              |           +--ro in-voa
-             |           |       l0-types-ext:power-in-db-or-null
+             |           |       l0-types:power-in-db-or-null
              |           +--ro total-output-power
-             |           |       l0-types-ext:power-in-db-or-null
+             |           |       l0-types:power-in-db-or-null
              |           +--ro (power-param)?
              |           |  +--:(channel-power)
              |           |  |  +--ro nominal-carrier-power?
-             |           |  |          l0-types-ext:power-in-dbm-or-null
+             |           |  |          l0-types:power-in-dbm-or-null
              |           |  +--:(power-spectral-density)
              |           |     +--ro nominal-power-spectral-density?
              |           |             union
              |           +--ro raman-direction?
              |           |       enumeration
              |           +--ro raman-pump* []
-             |              +--ro frequency?
-             |              |       l0-types-ext:frequency-thz
+             |              +--ro frequency?   l0-types:frequency-thz
              |              +--ro power?
-             |                      l0-types-ext:decimal-2-digits-or-null
+             |                      l0-types:decimal-2-digits-or-null
              +--:(fiber)
              |  +--ro fiber
              |     +--ro type-variety    string
              |     +--ro length
-             |     |       l0-types-ext:decimal-2-digits-or-null
+             |     |       l0-types:decimal-2-digits-or-null
              |     +--ro loss-coef
-             |     |       l0-types-ext:decimal-2-digits-or-null
-             |     +--ro total-loss
-             |     |       l0-types-ext:power-in-db-or-null
+             |     |       l0-types:decimal-2-digits-or-null
+             |     +--ro total-loss      l0-types:power-in-db-or-null
              |     +--ro pmd?
-             |     |       l0-types-ext:decimal-2-digits-or-null
-             |     +--ro conn-in?
-             |     |       l0-types-ext:power-in-db-or-null
-             |     +--ro conn-out?
-             |             l0-types-ext:power-in-db-or-null
+             |     |       l0-types:decimal-2-digits-or-null
+             |     +--ro conn-in?        l0-types:power-in-db-or-null
+             |     +--ro conn-out?       l0-types:power-in-db-or-null
              +--:(concentratedloss)
                 +--ro concentratedloss
-                   +--ro loss    l0-types-ext:power-in-db-or-null
+                   +--ro loss    l0-types:power-in-db-or-null
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:tunnel-termination-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
@@ -227,11 +222,11 @@ module: ietf-optical-impairment-topology
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?                 union
           |     +--ro roadm-pdl?
-          |     |       l0-types-ext:power-in-db-or-null
+          |     |       l0-types:power-in-db-or-null
           |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types-ext:power-in-db-or-null
+          |     |       l0-types:power-in-db-or-null
           |     +--ro roadm-maxloss?
-          |             l0-types-ext:power-in-db-or-null
+          |             l0-types:power-in-db-or-null
           +--:(roadm-add-path)
           |  +--ro roadm-add-path* []
           |     +--ro frequency-range
@@ -240,15 +235,14 @@ module: ietf-optical-impairment-topology
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?                 union
           |     +--ro roadm-pdl?
-          |     |       l0-types-ext:power-in-db-or-null
+          |     |       l0-types:power-in-db-or-null
           |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types-ext:power-in-db-or-null
+          |     |       l0-types:power-in-db-or-null
           |     +--ro roadm-maxloss?
-          |     |       l0-types-ext:power-in-db-or-null
+          |     |       l0-types:power-in-db-or-null
           |     +--ro roadm-pmax?
-          |     |       l0-types-ext:power-in-dbm-or-null
-          |     +--ro roadm-osnr?
-          |     |       l0-types-ext:snr-or-null
+          |     |       l0-types:power-in-dbm-or-null
+          |     +--ro roadm-osnr?               l0-types:snr-or-null
           |     +--ro roadm-noise-figure?       union
           +--:(roadm-drop-path)
              +--ro roadm-drop-path* []
@@ -258,23 +252,22 @@ module: ietf-optical-impairment-topology
                 +--ro roadm-pmd?                union
                 +--ro roadm-cd?                 union
                 +--ro roadm-pdl?
-                |       l0-types-ext:power-in-db-or-null
+                |       l0-types:power-in-db-or-null
                 +--ro roadm-inband-crosstalk?
-                |       l0-types-ext:power-in-db-or-null
+                |       l0-types:power-in-db-or-null
                 +--ro roadm-maxloss?
-                |       l0-types-ext:power-in-db-or-null
+                |       l0-types:power-in-db-or-null
                 +--ro roadm-minloss?
-                |       l0-types-ext:power-in-db-or-null
+                |       l0-types:power-in-db-or-null
                 +--ro roadm-typloss?
-                |       l0-types-ext:power-in-db-or-null
+                |       l0-types:power-in-db-or-null
                 +--ro roadm-pmin?
-                |       l0-types-ext:power-in-dbm-or-null
+                |       l0-types:power-in-dbm-or-null
                 +--ro roadm-pmax?
-                |       l0-types-ext:power-in-dbm-or-null
+                |       l0-types:power-in-dbm-or-null
                 +--ro roadm-ptyp?
-                |       l0-types-ext:power-in-dbm-or-null
-                +--ro roadm-osnr?
-                |       l0-types-ext:snr-or-null
+                |       l0-types:power-in-dbm-or-null
+                +--ro roadm-osnr?               l0-types:snr-or-null
                 +--ro roadm-noise-figure?       union
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:information-source-entry/tet:connectivity-matrices:

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -166,7 +166,8 @@ module ietf-optical-impairment-topology {
             type enumeration {
               enum co-propagating {
                 description
-                  "It means that the optical pumps are injected in
+                  "co-propagating indicates that optical pump light is injected in
+                  the same direction as the optical signal ... 
                   the same direction to the optical signal that is
                   amplified (forward pump).";
               }

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -49,7 +49,7 @@ module ietf-optical-impairment-topology {
     "This module contains a collection of YANG definitions for
      impairment-aware optical networks.
 
-     Copyright (c) 2021 IETF Trust and the persons identified as
+     Copyright (c) 2022 IETF Trust and the persons identified as
      authors of the code.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or
@@ -68,7 +68,7 @@ module ietf-optical-impairment-topology {
 // the format is (year-month-day)
 
 
-  revision 2022-03-02 {
+  revision 2022-03-03 {
     description
       "Initial Version";
     reference
@@ -166,17 +166,15 @@ module ietf-optical-impairment-topology {
             type enumeration {
               enum co-propagating {
                 description
-                  "co-propagating indicates that optical pump light is injected in
-                  the same direction as the optical signal ... 
-                  the same direction to the optical signal that is
-                  amplified (forward pump).";
+                  "Co-propagating indicates that optical pump light
+                  is injected in the same direction to the optical
+                  signal that is amplified (forward pump).";
               }
               enum counter-propagating {
                 description
-                  "counter-propagating indicates that optical pump light is injected in
-                  opposite direction ...
-                  opposite direction to the optical signal that is
-                  amplified (backward pump). ";
+                  "Counter-propagating indicates that optical pump
+                  light is injected in opposite direction to the
+                  optical signal that is amplified (backward pump).";
               }
             }
             description

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -173,7 +173,8 @@ module ietf-optical-impairment-topology {
               }
               enum counter-propagating {
                 description
-                  "It means that optical pumps are injected in
+                  "counter-propagating indicates that optical pump light is injected in
+                  opposite direction ...
                   opposite direction to the optical signal that is
                   amplified (backward pump). ";
               }

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -170,7 +170,7 @@ module ietf-optical-impairment-topology {
                   the same direction to the optical signal that is
                   amplified (forward pump).";
               }
-              enum contra-propagating {
+              enum counter-propagating {
                 description
                   "It means that optical pumps are injected in
                   opposite direction to the optical signal that is

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -68,7 +68,7 @@ module ietf-optical-impairment-topology {
 // the format is (year-month-day)
 
 
-  revision 2021-11-15 {
+  revision 2022-03-02 {
     description
       "Initial Version";
     reference
@@ -103,7 +103,7 @@ module ietf-optical-impairment-topology {
       description
         "amplifier type, operatonal parameters are described.";
       leaf type-variety {
-        type string ;
+        type string;
         mandatory true ;
         description
           "String identifier of amplifier type referencing
@@ -129,37 +129,73 @@ module ietf-optical-impairment-topology {
             uses l0-types-ext:frequency-range;
           }
           leaf actual-gain {
-            type decimal64 {
-              fraction-digits 2;
-            }
-            units dB ;
+            type l0-types-ext:power-in-db-or-null;
             mandatory true ;
             description "..";
           }
           leaf tilt-target {
-            type decimal64 {
-              fraction-digits 2;
-            }
+            type l0-types-ext:decimal-2-digits-or-null;
             mandatory true ;
             description "..";
           }
           leaf out-voa {
-            type decimal64 {
-              fraction-digits 2;
-            }
+            type l0-types-ext:power-in-db-or-null;
             units dB;
             mandatory true;
             description "..";
           }
           leaf in-voa {
-            type decimal64 {
-              fraction-digits 2;
-            }
-            units dB;
+            type l0-types-ext:power-in-db-or-null;
             mandatory true;
             description "..";
           }
+          leaf total-output-power {
+            type l0-types-ext:power-in-db-or-null;
+            mandatory true;
+            description
+              "It represent total output power measured in the range
+              specified by the frequency-range.
+              
+              Optical power is especially needed to re-compute/check
+              consistency of span (fiber+ concentrated loss) loss
+              value, with respect to loss/gain information on
+              elements.";
+          }
           uses power-param;
+          leaf raman-direction {
+            type enumeration {
+              enum co-propagating {
+                description
+                  "It means that the optical pumps are injected in
+                  the same direction to the optical signal that is
+                  amplified (forward pump).";
+              }
+              enum contra-propagating {
+                description
+                  "It means that optical pumps are injected in
+                  opposite direction to the optical signal that is
+                  amplified (backward pump). ";
+              }
+            }
+            description
+              "The direction of injection of the raman pump.";
+          }
+          list raman-pump {
+            description
+              "The list of pumps for the Raman amplifier.";
+            leaf frequency {
+              type l0-types-ext:frequency-thz;
+              description
+                "The raman pump central frequency.";
+            }
+            leaf power {
+              type l0-types-ext:decimal-2-digits-or-null;
+              units "Watts";
+              description
+                "The total pump power considering a depolarized pump
+                at the raman pump central frequency.";
+            }
+          }
         }  // list amplifier-element
       }  // container operational
     }  // container amplifier
@@ -170,58 +206,43 @@ module ietf-optical-impairment-topology {
       "String identifier of fiber type referencing a 
        specification in a separate equipment catalog";
     container fiber {
-    description "fiber characteristics";
+      description "fiber characteristics";
       leaf type-variety {
         type string ;
-    mandatory true ;
+        mandatory true ;
         description "fiber type";
       }
       leaf length {
-        type decimal64 {
-          fraction-digits 2;
-        }
+        type l0-types-ext:decimal-2-digits-or-null;
         units km;
-    mandatory true ;
-    description "length of fiber";
+        mandatory true ;
+        description "length of fiber";
       }
       leaf loss-coef {
-        type decimal64 {
-          fraction-digits 2;
-        }
+        type l0-types-ext:decimal-2-digits-or-null;
         units dB/km;
-    mandatory true ;
-    description "loss coefficient of the fiber";
+        mandatory true ;
+        description "loss coefficient of the fiber";
       }
       leaf total-loss {
-        type decimal64 {
-          fraction-digits 2;
-        }
-        units dB;
-    mandatory true ;
+        type l0-types-ext:power-in-db-or-null;
+        mandatory true ;
         description
           "includes all losses: fiber loss and conn-in and 
            conn-out losses";
       }
       leaf pmd{
-        type decimal64 {
-          fraction-digits 2;
-        }
+        type l0-types-ext:decimal-2-digits-or-null;
         units sqrt(ps);
-    description "pmd of the fiber";
+        description "pmd of the fiber";
       }
       leaf conn-in{
-        type decimal64 {
-          fraction-digits 2;
-        }
-        units dB;
-    description "connector-in";
+        type l0-types-ext:power-in-db-or-null;
+        description "connector-in";
       }
       leaf conn-out{
-        type decimal64 {
-          fraction-digits 2;
-        }
-        units dB;
-    description "connector-out";
+        type l0-types-ext:power-in-db-or-null;
+        description "connector-out";
       }
     }
   }
@@ -230,33 +251,33 @@ module ietf-optical-impairment-topology {
     description
       "The optical impairments of a ROADM express path.";
     leaf roadm-pmd {
-      type decimal64 {
-        fraction-digits 8;
-        range "0..max";
+      type union {
+        type decimal64 {
+          fraction-digits 8;
+          range "0..max";
+        }
+        type empty;
       }
       units "ps/(km)^0.5"; 
       description 
         "Polarization Mode Dispersion";
     }
     leaf roadm-cd {
-      type decimal64 {
-        fraction-digits 5;
+      type union {
+        type decimal64 {
+          fraction-digits 5;
+        }
+        type empty;
       }
       units "ps/nm";
       description "Chromatic Dispersion";
     }            
     leaf roadm-pdl {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB ;
+      type l0-types-ext:power-in-db-or-null;
       description "Polarization dependent loss";        
     }      
     leaf roadm-inband-crosstalk {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB;
+      type l0-types-ext:power-in-db-or-null;
       description
         "In-band crosstalk, or coherent crosstalk, can occur in
           components that can have multiple same wavelength inputs
@@ -264,10 +285,7 @@ module ietf-optical-impairment-topology {
           or all but 1 blocked";
     }
     leaf roadm-maxloss {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB;
+      type l0-types-ext:power-in-db-or-null;
       description
         "This is the maximum expected add path loss from the 
           ROADM ingress to the ROADM egress 
@@ -278,33 +296,33 @@ module ietf-optical-impairment-topology {
   grouping roadm-add-path {
     description "The optical impairments of a ROADM add path.";   
     leaf roadm-pmd {
-      type decimal64 {
-        fraction-digits 8;
-        range "0..max";
+      type union {
+        type decimal64 {
+          fraction-digits 8;
+          range "0..max";
+        }
+        type empty;
       }
       units "ps"; 
       description 
         "Polarization Mode Dispersion";
     }
     leaf roadm-cd {
-      type decimal64 {
-        fraction-digits 5;
+      type union {
+        type decimal64 {
+          fraction-digits 5;
+        }
+        type empty;
       }
       units "ps/nm"; 
       description "Cromatic Dispersion";
     }            
     leaf roadm-pdl {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB ;
+      type l0-types-ext:power-in-db-or-null;
       description "Polarization dependent loss";      
     }      
     leaf roadm-inband-crosstalk {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB ;
+      type l0-types-ext:power-in-db-or-null;
       description
         "In-band crosstalk, or coherent crosstalk, 
           can occur in components that can have multiple same
@@ -316,10 +334,7 @@ module ietf-optical-impairment-topology {
           + egress WSS crosstalk contributions.";
     }
     leaf roadm-maxloss {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB ;
+      type l0-types-ext:power-in-db-or-null;
       description 
         "This is the maximum expected add path loss from 
           the add/drop port input to the ROADM egress, 
@@ -335,10 +350,7 @@ module ietf-optical-impairment-topology {
           ripple or gain uncertainty";        
     }
     leaf roadm-pmax {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dBm ;
+      type l0-types-ext:power-in-dbm-or-null;
       description 
         "This is the maximum (per carrier) power level 
           permitted at the add block input ports,
@@ -350,7 +362,7 @@ module ietf-optical-impairment-topology {
           to this value or lower";
     }
     leaf roadm-osnr {
-      type l0-types-ext:snr; 
+      type l0-types-ext:snr-or-null;
       description 
         "Optical Signal-to-Noise Ratio (OSNR).
           If the add path contains the ability to adjust the 
@@ -363,8 +375,11 @@ module ietf-optical-impairment-topology {
           (if both are defined).";
     }
     leaf roadm-noise-figure {
-      type decimal64 {
-        fraction-digits 5;
+      type union {
+        type decimal64 {
+          fraction-digits 5;
+        }
+        type empty;
       }
       units "dB"; 
       description 
@@ -381,33 +396,33 @@ module ietf-optical-impairment-topology {
   grouping roadm-drop-path {
     description "roadm drop block path optical impairments";
     leaf roadm-pmd {
-      type decimal64 {
-        fraction-digits 8;
-        range "0..max";
+      type union {
+        type decimal64 {
+          fraction-digits 8;
+          range "0..max";
+        }
+        type empty;
       }
       units "ps/(km)^0.5"; 
       description 
         "Polarization Mode Dispersion";
     }
     leaf roadm-cd {
-      type decimal64 {
-        fraction-digits 5;
+      type union {
+        type decimal64 {
+          fraction-digits 5;
+        }
+        type empty;
       }
       units "ps/nm"; 
       description "Chromatic Dispersion";
     }            
     leaf roadm-pdl {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB ;
+      type l0-types-ext:power-in-db-or-null;
       description "Polarization dependent loss";        
     }      
     leaf roadm-inband-crosstalk {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB;
+      type l0-types-ext:power-in-db-or-null;
       description
         "In-band crosstalk, or coherent crosstalk, can occur in
           components that can have multiple same wavelength 
@@ -419,10 +434,7 @@ module ietf-optical-impairment-topology {
           contributions.";
     }
     leaf roadm-maxloss {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB ;
+      type l0-types-ext:power-in-db-or-null;
       description 
         "The net loss from the ROADM input,to the output 
           of the drop block. 
@@ -437,10 +449,7 @@ module ietf-optical-impairment-topology {
           amplifier.";        
     }
     leaf roadm-minloss {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB ;
+      type l0-types-ext:power-in-db-or-null;
       description 
         "The net loss from the ROADM input, to the 
           output of the drop block.
@@ -453,10 +462,7 @@ module ietf-optical-impairment-topology {
           including amplifier gain ripple or uncertainty.";        
     }
     leaf roadm-typloss {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dB ;
+      type l0-types-ext:power-in-db-or-null;
       description 
         "The net loss from the ROADM input, 
           to the output of the drop block.
@@ -471,10 +477,7 @@ module ietf-optical-impairment-topology {
           expected loss.";        
     }
     leaf roadm-pmin {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dBm ;
+      type l0-types-ext:power-in-dbm-or-null;
       description 
         "If the drop path has additional loss
           that is added, for example,
@@ -492,10 +495,7 @@ module ietf-optical-impairment-topology {
           detailed in section xxx of the document yyy."; 
     }
     leaf roadm-pmax {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dBm ;
+      type l0-types-ext:power-in-dbm-or-null;
       description 
         "If the drop path has additional loss that is added, 
           for example, to hit target power levels into a 
@@ -511,10 +511,7 @@ module ietf-optical-impairment-topology {
           is detailed in section xxx of the document yyy";        
     }
     leaf roadm-ptyp {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      units dBm ;
+      type l0-types-ext:power-in-dbm-or-null;
       description 
         "If the drop path has additional loss that is added,
           for example, to hit target power levels into a 
@@ -527,7 +524,7 @@ module ietf-optical-impairment-topology {
           at the output of the drop block.";        
     }
     leaf roadm-osnr {
-      type l0-types-ext:snr; 
+      type l0-types-ext:snr-or-null; 
       description 
         "Optical Signal-to-Noise Ratio (OSNR).
           Expected OSNR contribution of the drop path
@@ -544,8 +541,11 @@ module ietf-optical-impairment-topology {
           the minimum value between these two should be used";
     }
     leaf roadm-noise-figure {
-      type decimal64 {
-        fraction-digits 5;
+      type union {
+        type decimal64 {
+          fraction-digits 5;
+        }
+        type empty;
       }
       units "dB"; 
       description 
@@ -568,12 +568,9 @@ module ietf-optical-impairment-topology {
   grouping concentratedloss-params{
     description "concentrated loss";
     container concentratedloss{
-    description "concentrated loss";
+      description "concentrated loss";
       leaf loss {
-        type decimal64 {
-          fraction-digits 2;
-        }
-        units dB ;
+        type l0-types-ext:power-in-db-or-null;
         mandatory true;
         description "..";
       }
@@ -591,10 +588,7 @@ module ietf-optical-impairment-topology {
             /tet:te-link-attributes/OMS-attributes
             /equalization-mode='carrier-power'";
         leaf nominal-carrier-power{
-          type decimal64 {
-              fraction-digits 2;
-          }
-          units dBm ;
+          type l0-types-ext:power-in-dbm-or-null;
           description
             " Reference channel power. Same grouping is used for the
             OMS power after the ROADM (input of the OMS) or after the
@@ -606,8 +600,11 @@ module ietf-optical-impairment-topology {
             /tet:te-link-attributes/OMS-attributes
             /equalization-mode='power-spectral-density'";
         leaf nominal-power-spectral-density{
-          type decimal64 {
-              fraction-digits 16;
+          type union {
+            type decimal64 {
+                fraction-digits 16;
+            }
+            type empty;
           }
           units W/Hz ;
           description
@@ -694,10 +691,7 @@ module ietf-optical-impairment-topology {
              the related OTSiG to get otsi identifier";
         }
         leaf delta-power{
-          type decimal64 {
-              fraction-digits 2;
-          }
-          units dB ;
+          type l0-types-ext:power-in-dbm-or-null;
           description
             " Deviation from the reference carrier power defined for
             the OMS.";
@@ -709,60 +703,63 @@ module ietf-optical-impairment-topology {
   grouping oms-element {
     description "OMS description";
     list OMS-elements {
-        key "elt-index";
+      key "elt-index";
+      description
+        "defines the spans and the amplifier blocks of 
+        the amplified lines";
+      leaf elt-index {
+        type uint16;
         description
-          "defines the spans and the amplifier blocks of 
-          the amplified lines";
-        leaf elt-index {
-          type uint16;
-          description
-            "ordered list of Index of OMS element 
-            (whether it's a Fiber, an EDFA or a
-            Concentratedloss)";
-        }
-        leaf oms-element-uid {
+          "ordered list of Index of OMS element 
+          (whether it's a Fiber, an EDFA or a
+          Concentratedloss)";
+      }
+      leaf oms-element-uid {
+        type union {
           type string;
+          type empty;
+        }
+        description
+          "unique id of the element if it exists";
+      }
+      container reverse-element-ref {
+        description
+          "It contains references to the elements which are
+          associated with this element in the reverse
+          direction.";
+        leaf link-ref {
+          type leafref {
+            path "../../../../../../../nt:link/nt:link-id";
+          }
           description
-            "unique id of the element if it exists";
+            "The reference to the OMS link which the OMS elements
+            belongs to.";
         }
-        container reverse-element-ref {
+        leaf-list oms-element-ref {
+          type leafref {
+            path "../../../../../../../nt:link[nt:link-id="
+                + "current()/../link-ref]/tet:te/"
+                + "tet:te-link-attributes/OMS-attributes/"
+                + "OMS-elements/elt-index";
+          }
           description
-            "It contains references to the elements which are
-            associated with this element in the reverse
-            direction.";
-          leaf link-ref {
-            type leafref {
-              path "../../../../../../../nt:link/nt:link-id";
-            }
-            description
-              "The reference to the OMS link which the OMS elements
-              belongs to.";
-          }
-          leaf-list oms-element-ref {
-            type leafref {
-              path "../../../../../../../nt:link[nt:link-id="
-                 + "current()/../link-ref]/tet:te/"
-                 + "tet:te-link-attributes/OMS-attributes/"
-                 + "OMS-elements/elt-index";
-            }
-            description
-              "The references to the OMS elements.";
-          }
+            "The references to the OMS elements.";
         }
-        choice element {
-          mandatory true;
-          description "OMS element type";
-          case amplifier {
-            uses tet:geolocation-container;
-            uses amplifier-params;
-          }
-          case fiber {
-            uses fiber-params;
-          }
-          case concentratedloss {
-            uses concentratedloss-params ;
-          }
+      }
+      choice element {
+        mandatory true;
+        description "OMS element type";
+        case amplifier {
+          uses tet:geolocation-container;
+          uses amplifier-params;
         }
+        case fiber {
+          uses fiber-params;
+        }
+        case concentratedloss {
+          uses concentratedloss-params ;
+        }
+      }
     }
   }
 

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -22,10 +22,6 @@ module ietf-optical-impairment-topology {
     prefix "l0-types";
   }
 
-  import ietf-layer0-types-ext {
-    prefix "l0-types-ext";
-  }
-
   organization
     "IETF CCAMP Working Group";
 
@@ -49,6 +45,19 @@ module ietf-optical-impairment-topology {
     "This module contains a collection of YANG definitions for
      impairment-aware optical networks.
 
+     Within this module, if the value of a mandatory attribute is
+     unknown, it MUST be reported using the empty type.
+     If an optional attribute is applicable but its value is unknown,
+     it MUST be reported using the empty type.
+     If an optional attribute is not applicable to an entity, it MUST
+     be omitted (not be present in the datastore).
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+
      Copyright (c) 2022 IETF Trust and the persons identified as
      authors of the code.  All rights reserved.
 
@@ -68,7 +77,7 @@ module ietf-optical-impairment-topology {
 // the format is (year-month-day)
 
 
-  revision 2022-03-03 {
+  revision 2022-03-07 {
     description
       "Initial Version";
     reference
@@ -126,31 +135,31 @@ module ietf-optical-impairment-topology {
             description
               "The frequency range amplified by the amplifier
               element.";
-            uses l0-types-ext:frequency-range;
+            uses l0-types:frequency-range;
           }
           leaf actual-gain {
-            type l0-types-ext:power-in-db-or-null;
+            type l0-types:power-in-db-or-null;
             mandatory true ;
             description "..";
           }
           leaf tilt-target {
-            type l0-types-ext:decimal-2-digits-or-null;
+            type l0-types:decimal-2-digits-or-null;
             mandatory true ;
             description "..";
           }
           leaf out-voa {
-            type l0-types-ext:power-in-db-or-null;
+            type l0-types:power-in-db-or-null;
             units dB;
             mandatory true;
             description "..";
           }
           leaf in-voa {
-            type l0-types-ext:power-in-db-or-null;
+            type l0-types:power-in-db-or-null;
             mandatory true;
             description "..";
           }
           leaf total-output-power {
-            type l0-types-ext:power-in-db-or-null;
+            type l0-types:power-in-db-or-null;
             mandatory true;
             description
               "It represent total output power measured in the range
@@ -184,12 +193,12 @@ module ietf-optical-impairment-topology {
             description
               "The list of pumps for the Raman amplifier.";
             leaf frequency {
-              type l0-types-ext:frequency-thz;
+              type l0-types:frequency-thz;
               description
                 "The raman pump central frequency.";
             }
             leaf power {
-              type l0-types-ext:decimal-2-digits-or-null;
+              type l0-types:decimal-2-digits-or-null;
               units "Watts";
               description
                 "The total pump power considering a depolarized pump
@@ -213,35 +222,35 @@ module ietf-optical-impairment-topology {
         description "fiber type";
       }
       leaf length {
-        type l0-types-ext:decimal-2-digits-or-null;
+        type l0-types:decimal-2-digits-or-null;
         units km;
         mandatory true ;
         description "length of fiber";
       }
       leaf loss-coef {
-        type l0-types-ext:decimal-2-digits-or-null;
+        type l0-types:decimal-2-digits-or-null;
         units dB/km;
         mandatory true ;
         description "loss coefficient of the fiber";
       }
       leaf total-loss {
-        type l0-types-ext:power-in-db-or-null;
+        type l0-types:power-in-db-or-null;
         mandatory true ;
         description
           "includes all losses: fiber loss and conn-in and 
            conn-out losses";
       }
       leaf pmd{
-        type l0-types-ext:decimal-2-digits-or-null;
+        type l0-types:decimal-2-digits-or-null;
         units sqrt(ps);
         description "pmd of the fiber";
       }
       leaf conn-in{
-        type l0-types-ext:power-in-db-or-null;
+        type l0-types:power-in-db-or-null;
         description "connector-in";
       }
       leaf conn-out{
-        type l0-types-ext:power-in-db-or-null;
+        type l0-types:power-in-db-or-null;
         description "connector-out";
       }
     }
@@ -273,11 +282,11 @@ module ietf-optical-impairment-topology {
       description "Chromatic Dispersion";
     }            
     leaf roadm-pdl {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description "Polarization dependent loss";        
     }      
     leaf roadm-inband-crosstalk {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description
         "In-band crosstalk, or coherent crosstalk, can occur in
           components that can have multiple same wavelength inputs
@@ -285,7 +294,7 @@ module ietf-optical-impairment-topology {
           or all but 1 blocked";
     }
     leaf roadm-maxloss {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description
         "This is the maximum expected add path loss from the 
           ROADM ingress to the ROADM egress 
@@ -318,11 +327,11 @@ module ietf-optical-impairment-topology {
       description "Cromatic Dispersion";
     }            
     leaf roadm-pdl {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description "Polarization dependent loss";      
     }      
     leaf roadm-inband-crosstalk {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description
         "In-band crosstalk, or coherent crosstalk, 
           can occur in components that can have multiple same
@@ -334,7 +343,7 @@ module ietf-optical-impairment-topology {
           + egress WSS crosstalk contributions.";
     }
     leaf roadm-maxloss {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description 
         "This is the maximum expected add path loss from 
           the add/drop port input to the ROADM egress, 
@@ -350,7 +359,7 @@ module ietf-optical-impairment-topology {
           ripple or gain uncertainty";        
     }
     leaf roadm-pmax {
-      type l0-types-ext:power-in-dbm-or-null;
+      type l0-types:power-in-dbm-or-null;
       description 
         "This is the maximum (per carrier) power level 
           permitted at the add block input ports,
@@ -362,7 +371,7 @@ module ietf-optical-impairment-topology {
           to this value or lower";
     }
     leaf roadm-osnr {
-      type l0-types-ext:snr-or-null;
+      type l0-types:snr-or-null;
       description 
         "Optical Signal-to-Noise Ratio (OSNR).
           If the add path contains the ability to adjust the 
@@ -418,11 +427,11 @@ module ietf-optical-impairment-topology {
       description "Chromatic Dispersion";
     }            
     leaf roadm-pdl {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description "Polarization dependent loss";        
     }      
     leaf roadm-inband-crosstalk {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description
         "In-band crosstalk, or coherent crosstalk, can occur in
           components that can have multiple same wavelength 
@@ -434,7 +443,7 @@ module ietf-optical-impairment-topology {
           contributions.";
     }
     leaf roadm-maxloss {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description 
         "The net loss from the ROADM input,to the output 
           of the drop block. 
@@ -449,7 +458,7 @@ module ietf-optical-impairment-topology {
           amplifier.";        
     }
     leaf roadm-minloss {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description 
         "The net loss from the ROADM input, to the 
           output of the drop block.
@@ -462,7 +471,7 @@ module ietf-optical-impairment-topology {
           including amplifier gain ripple or uncertainty.";        
     }
     leaf roadm-typloss {
-      type l0-types-ext:power-in-db-or-null;
+      type l0-types:power-in-db-or-null;
       description 
         "The net loss from the ROADM input, 
           to the output of the drop block.
@@ -477,7 +486,7 @@ module ietf-optical-impairment-topology {
           expected loss.";        
     }
     leaf roadm-pmin {
-      type l0-types-ext:power-in-dbm-or-null;
+      type l0-types:power-in-dbm-or-null;
       description 
         "If the drop path has additional loss
           that is added, for example,
@@ -495,7 +504,7 @@ module ietf-optical-impairment-topology {
           detailed in section xxx of the document yyy."; 
     }
     leaf roadm-pmax {
-      type l0-types-ext:power-in-dbm-or-null;
+      type l0-types:power-in-dbm-or-null;
       description 
         "If the drop path has additional loss that is added, 
           for example, to hit target power levels into a 
@@ -511,7 +520,7 @@ module ietf-optical-impairment-topology {
           is detailed in section xxx of the document yyy";        
     }
     leaf roadm-ptyp {
-      type l0-types-ext:power-in-dbm-or-null;
+      type l0-types:power-in-dbm-or-null;
       description 
         "If the drop path has additional loss that is added,
           for example, to hit target power levels into a 
@@ -524,7 +533,7 @@ module ietf-optical-impairment-topology {
           at the output of the drop block.";        
     }
     leaf roadm-osnr {
-      type l0-types-ext:snr-or-null; 
+      type l0-types:snr-or-null; 
       description 
         "Optical Signal-to-Noise Ratio (OSNR).
           Expected OSNR contribution of the drop path
@@ -570,7 +579,7 @@ module ietf-optical-impairment-topology {
     container concentratedloss{
       description "concentrated loss";
       leaf loss {
-        type l0-types-ext:power-in-db-or-null;
+        type l0-types:power-in-db-or-null;
         mandatory true;
         description "..";
       }
@@ -588,7 +597,7 @@ module ietf-optical-impairment-topology {
             /tet:te-link-attributes/OMS-attributes
             /equalization-mode='carrier-power'";
         leaf nominal-carrier-power{
-          type l0-types-ext:power-in-dbm-or-null;
+          type l0-types:power-in-dbm-or-null;
           description
             " Reference channel power. Same grouping is used for the
             OMS power after the ROADM (input of the OMS) or after the
@@ -619,12 +628,12 @@ module ietf-optical-impairment-topology {
   grouping oms-general-optical-params {
     description "OMS link optical parameters";
     leaf generalized-snr {
-      type l0-types-ext:snr;
+      type l0-types:snr;
       description "generalized snr";
     }
     leaf equalization-mode{
       type identityref {
-        base l0-types-ext:type-power-mode;
+        base l0-types:type-power-mode;
       }
       mandatory true;
       description "equalization mode";
@@ -646,7 +655,7 @@ module ietf-optical-impairment-topology {
         type uint16;
         description "OTSi carrier-id";
       }
-      uses l0-types-ext:common-transceiver-configured-param;
+      uses l0-types:common-transceiver-configured-param;
     } // OTSi list
   } // OTSiG grouping
 
@@ -691,7 +700,7 @@ module ietf-optical-impairment-topology {
              the related OTSiG to get otsi identifier";
         }
         leaf delta-power{
-          type l0-types-ext:power-in-dbm-or-null;
+          type l0-types:power-in-dbm-or-null;
           description
             " Deviation from the reference carrier power defined for
             the OMS.";
@@ -890,7 +899,7 @@ module ietf-optical-impairment-topology {
           type uint32;
           description "transceiver identifier";
         }
-        uses l0-types-ext:transceiver-capabilities;
+        uses l0-types:transceiver-capabilities;
         leaf configured-mode {
           type leafref {
             path "../supported-modes/supported-mode/mode-id";
@@ -1070,7 +1079,7 @@ module ietf-optical-impairment-topology {
               description
                 "The frequency range for which these optical
                 impairments apply.";
-              uses l0-types-ext:frequency-range;
+              uses l0-types:frequency-range;
             }
             uses roadm-express-path;
           } 
@@ -1087,7 +1096,7 @@ module ietf-optical-impairment-topology {
               description
                 "The frequency range for which these optical
                 impairments apply.";
-              uses l0-types-ext:frequency-range;
+              uses l0-types:frequency-range;
             }
             uses roadm-add-path; 
           }
@@ -1104,7 +1113,7 @@ module ietf-optical-impairment-topology {
               description
                 "The frequency range for which these optical
                 impairments apply.";
-              uses l0-types-ext:frequency-range;
+              uses l0-types:frequency-range;
             }
             uses roadm-drop-path; 
           }

--- a/tests/test_yang.py
+++ b/tests/test_yang.py
@@ -40,9 +40,8 @@ urls = [(official_yang_repo, 'standard/ietf/RFC/ietf-network@2018-02-26.yang'),
         (official_yang_repo, 'standard/ietf/RFC/ietf-network-topology@2018-02-26.yang'),
         (official_yang_repo, 'standard/ietf/RFC/ietf-inet-types@2013-07-15.yang'),
         (official_yang_repo, 'standard/ietf/RFC/ietf-te-types@2020-06-10.yang'),
-        (official_yang_repo, 'experimental/ietf-extracted-YANG-modules/ietf-layer0-types@2020-12-29.yang'),
         (official_yang_repo, 'standard/ietf/RFC/ietf-te-topology@2020-08-06.yang'),
-        (layer0ext_repo, 'ietf-layer0-types-ext.yang')]
+        (layer0ext_repo, 'ietf-layer0-types.yang')]
 # TODO automatically retrieve list of versions based on listing in the github
 
 for url in urls:


### PR DESCRIPTION
Fix #85
- added total-output-power to the amplifier-params grouping
Fix #99 :
- Updated types with union with type empty when applicable
Fix #100
- via PR https://github.com/ietf-ccamp-wg/ietf-ccamp-layer0-types-ext/pull/36
Fix #102 :
- added raman-direction to the amplifier-params grouping
- added raman-pump list to the amplifier-params grouping
Fix #103 
- aligned with the latest update of layer0-types revision

Pending merge of:

- [x] https://github.com/ietf-ccamp-wg/ietf-ccamp-layer0-types-ext/pull/36

Co-Authored-By: sergio belotti <sergio.belotti@nokia.com>