### PR TITLE
YANG updates for IETF 118

### DIFF
--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -41,11 +41,16 @@ module: ietf-optical-impairment-topology
     |        |        |     |       frequency-thz
     |        |        |     +--ro transceiver-tunability?
     |        |        |     |       frequency-ghz
-    |        |        |     +--ro tx-channel-power-min?      dbm-t
-    |        |        |     +--ro tx-channel-power-max?      dbm-t
-    |        |        |     +--ro rx-channel-power-min?      dbm-t
-    |        |        |     +--ro rx-channel-power-max?      dbm-t
-    |        |        |     +--ro rx-total-power-max?        dbm-t
+    |        |        |     +--ro tx-channel-power-min?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro tx-channel-power-max?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro rx-channel-power-min?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro rx-channel-power-max?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro rx-total-power-max?
+    |        |        |             power-in-dbm
     |        |        +--:(explicit-mode)
     |        |           +--ro explicit-mode
     |        |              +--ro line-coding-bitrate?
@@ -75,9 +80,10 @@ module: ietf-optical-impairment-topology
     |        |              +--ro min-OSNR?
     |        |              |       snr
     |        |              +--ro rx-ref-channel-power?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro rx-channel-power-penalty* []
-    |        |              |  +--ro rx-channel-power-value    union
+    |        |              |  +--ro rx-channel-power-value
+    |        |              |  |       power-in-dbm-or-null
     |        |              |  +--ro penalty-value             union
     |        |              +--ro min-Q-factor?
     |        |              |       int32
@@ -108,15 +114,15 @@ module: ietf-optical-impairment-topology
     |        |              +--ro transceiver-tunability?
     |        |              |       frequency-ghz
     |        |              +--ro tx-channel-power-min?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro tx-channel-power-max?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro rx-channel-power-min?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro rx-channel-power-max?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro rx-total-power-max?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro compatible-modes
     |        |                 +--ro supported-application-codes*
     |        |                 |       -> ../../../mode-id
@@ -142,8 +148,7 @@ module: ietf-optical-impairment-topology
           +--ro group-id           uint32
           +--ro regen-metric?      uint32
           +--ro transponder-ref*
-                  -> ../../../transponders/transponder/transponder-i\
-d
+                  -> ../../../transponders/transponder/transponder-id
   augment /nw:networks/nw:network/nt:link/tet:te
             /tet:te-link-attributes:
     +--ro OMS-attributes
@@ -165,8 +170,7 @@ d
        |        +--ro otsi-ref* []
        |        |  +--ro otsi-carrier-ref?   leafref
        |        |  +--ro e2e-mc-path-ref*    leafref
-       |        +--ro delta-power?      l0-types:power-in-dbm-or-nul\
-l
+       |        +--ro delta-power?      l0-types:gain-in-db-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
@@ -179,26 +183,23 @@ l
                 +--:(amplifier)
                 |  +--ro geolocation
                 |  |  +--ro altitude?    int64
-                |  |  +--ro latitude?    geographic-coordinate-degre\
-e
-                |  |  +--ro longitude?   geographic-coordinate-degre\
-e
+                |  |  +--ro latitude?    geographic-coordinate-degree
+                |  |  +--ro longitude?   geographic-coordinate-degree
                 |  +--ro amplifier
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element* []
                 |           +--ro name?
                 |           |       string
+                |           +--ro is-dynamic-gain-equalyzer?
+                |           |       boolean
                 |           +--ro frequency-range
-                |           |  +--ro lower-frequency    frequency-th\
-z
-                |           |  +--ro upper-frequency    frequency-th\
-z
+                |           |  +--ro lower-frequency    frequency-thz
+                |           |  +--ro upper-frequency    frequency-thz
                 |           +--ro actual-gain
                 |           |       l0-types:gain-in-db-or-null
                 |           +--ro tilt-target
-                |           |       l0-types:decimal-2-digits-or-nul\
-l
+                |           |       l0-types:decimal-2-digits-or-null
                 |           +--ro out-voa
                 |           |       l0-types:loss-in-db-or-null
                 |           +--ro in-voa
@@ -218,10 +219,22 @@ ty?
                 |           +--ro raman-direction?
                 |           |       enumeration
                 |           +--ro raman-pump* []
-                |              +--ro frequency?
-                |              |       l0-types:frequency-thz
-                |              +--ro power?
-                |                      l0-types:decimal-2-digits-or-\
+                |           |  +--ro frequency?
+                |           |  |       l0-types:frequency-thz
+                |           |  +--ro power?
+                |           |          l0-types:decimal-2-digits-or-\
+null
+                |           +--ro pdl?
+                |           |       l0-types:loss-in-db-or-null
+                |           +--ro media-channel-groups
+                |              +--ro media-channel-group* []
+                |                 +--ro media-channels* []
+                |                    +--ro flexi-n?
+                |                    |       l0-types:flexi-n
+                |                    +--ro flexi-m?
+                |                    |       l0-types:flexi-m
+                |                    +--ro delta-power?
+                |                            l0-types:gain-in-db-or-\
 null
                 +--:(fiber)
                 |  +--ro fiber
@@ -245,8 +258,7 @@ null
             /tet:tunnel-termination-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
        +--ro transponder-ref
-       |       -> ../../../../transponders/transponder/transponder-i\
-d
+       |       -> ../../../../transponders/transponder/transponder-id
        +--ro transceiver-ref    leafref
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:tunnel-termination-point:
@@ -254,6 +266,9 @@ d
        +--ro carrier-id    uint32
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw protection-type?   identityref
+  augment /nw:networks/nw:network/nw:node/nt:termination-point
+            /tet:te:
+    +--rw inter-layer-sequence-number?   uint32
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:te-node-attributes:
     +--ro roadm-path-impairments* [roadm-path-impairments-id]
@@ -329,8 +344,7 @@ d
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:te-node-attributes/tet:connectivity-matrices:
     +--ro roadm-path-impairments?
-            -> ../../roadm-path-impairments/roadm-path-impairments-i\
-d
+            -> ../../roadm-path-impairments/roadm-path-impairments-id
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:te-node-attributes/tet:connectivity-matrices
             /tet:connectivity-matrix:

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -189,6 +189,8 @@ module: ietf-optical-impairment-topology
                 |        +--ro amplifier-element* []
                 |           +--ro name?
                 |           |       string
+                |           +--ro is-dynamic-gain-equalyzer?
+                |           |       boolean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
@@ -212,10 +214,21 @@ module: ietf-optical-impairment-topology
                 |           +--ro raman-direction?
                 |           |       enumeration
                 |           +--ro raman-pump* []
-                |              +--ro frequency?
-                |              |       l0-types:frequency-thz
-                |              +--ro power?
-                |                      l0-types:decimal-2-digits-or-null
+                |           |  +--ro frequency?
+                |           |  |       l0-types:frequency-thz
+                |           |  +--ro power?
+                |           |          l0-types:decimal-2-digits-or-null
+                |           +--ro pdl?
+                |           |       l0-types:loss-in-db-or-null
+                |           +--ro media-channel-groups
+                |              +--ro media-channel-group* []
+                |                 +--ro media-channels* []
+                |                    +--ro flexi-n?
+                |                    |       l0-types:flexi-n
+                |                    +--ro flexi-m?
+                |                    |       l0-types:flexi-m
+                |                    +--ro delta-power?
+                |                            l0-types:power-in-dbm-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -246,6 +246,9 @@ module: ietf-optical-impairment-topology
        +--ro carrier-id    uint32
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw protection-type?   identityref
+  augment /nw:networks/nw:network/nw:node/nt:termination-point
+            /tet:te:
+    +--rw inter-layer-sequence-number?   uint32
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:te-node-attributes:
     +--ro roadm-path-impairments* [roadm-path-impairments-id]

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -39,11 +39,16 @@ module: ietf-optical-impairment-topology
     |        |        |     |       frequency-thz
     |        |        |     +--ro transceiver-tunability?
     |        |        |     |       frequency-ghz
-    |        |        |     +--ro tx-channel-power-min?      dbm-t
-    |        |        |     +--ro tx-channel-power-max?      dbm-t
-    |        |        |     +--ro rx-channel-power-min?      dbm-t
-    |        |        |     +--ro rx-channel-power-max?      dbm-t
-    |        |        |     +--ro rx-total-power-max?        dbm-t
+    |        |        |     +--ro tx-channel-power-min?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro tx-channel-power-max?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro rx-channel-power-min?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro rx-channel-power-max?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro rx-total-power-max?
+    |        |        |             power-in-dbm
     |        |        +--:(explicit-mode)
     |        |           +--ro explicit-mode
     |        |              +--ro line-coding-bitrate?
@@ -73,9 +78,10 @@ module: ietf-optical-impairment-topology
     |        |              +--ro min-OSNR?
     |        |              |       snr
     |        |              +--ro rx-ref-channel-power?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro rx-channel-power-penalty* []
-    |        |              |  +--ro rx-channel-power-value    union
+    |        |              |  +--ro rx-channel-power-value
+    |        |              |  |       power-in-dbm-or-null
     |        |              |  +--ro penalty-value             union
     |        |              +--ro min-Q-factor?
     |        |              |       int32
@@ -106,15 +112,15 @@ module: ietf-optical-impairment-topology
     |        |              +--ro transceiver-tunability?
     |        |              |       frequency-ghz
     |        |              +--ro tx-channel-power-min?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro tx-channel-power-max?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro rx-channel-power-min?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro rx-channel-power-max?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro rx-total-power-max?
-    |        |              |       dbm-t
+    |        |              |       power-in-dbm
     |        |              +--ro compatible-modes
     |        |                 +--ro supported-application-codes*
     |        |                 |       -> ../../../mode-id

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -168,7 +168,7 @@ module: ietf-optical-impairment-topology
        |        +--ro otsi-ref* []
        |        |  +--ro otsi-carrier-ref?   leafref
        |        |  +--ro e2e-mc-path-ref*    leafref
-       |        +--ro delta-power?      l0-types:power-in-dbm-or-null
+       |        +--ro delta-power?      l0-types:gain-in-db-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
@@ -228,7 +228,7 @@ module: ietf-optical-impairment-topology
                 |                    +--ro flexi-m?
                 |                    |       l0-types:flexi-m
                 |                    +--ro delta-power?
-                |                            l0-types:power-in-dbm-or-null
+                |                            l0-types:gain-in-db-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -263,7 +263,7 @@ module ietf-optical-impairment-topology {
                 uses l0-types:flexi-grid-frequency-slot;
 
                 leaf delta-power {
-                  type l0-types:power-in-dbm-or-null;
+                  type l0-types:gain-in-db-or-null;
                   description
                     " Deviation from the reference carrier power 
                     defined for the OMS.";
@@ -760,7 +760,7 @@ module ietf-optical-impairment-topology {
             }
           }
           leaf delta-power {
-            type l0-types:power-in-dbm-or-null;
+            type l0-types:gain-in-db-or-null;
             description
               " Deviation from the reference carrier power defined 
               for the OMS.";

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -87,7 +87,7 @@ module ietf-optical-impairment-topology {
 // this note
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2023-10-04 {
+  revision 2023-10-19 {
     description
       "Initial Version";
     reference
@@ -152,6 +152,12 @@ module ietf-optical-impairment-topology {
               "The name of the amplifier element as specified in
               the vendor's specification associated with the
               type-variety.";
+          }
+          leaf is-dynamic-gain-equalyzer {
+            type boolean;
+            description
+              "Indicates whether the amplifier element is a Dynamic 
+              Gain Equalizer (DGE).";
           }
           container frequency-range {
             description
@@ -237,6 +243,34 @@ module ietf-optical-impairment-topology {
                 at the raman pump central frequency.";
             }
           }
+          leaf pdl {
+            type l0-types:loss-in-db-or-null;
+            description "Polarization Dependent Loss (PDL)";
+          }
+          container media-channel-groups {
+            description
+              "The top level container for the list of media channel 
+              groups.";
+            list media-channel-group {
+              description
+                "The list of media channel groups";
+              list media-channels {
+                // key "flexi-n";
+                description
+                  "List of media channels represented as (n,m)";
+
+                // this grouping add both n.m values
+                uses l0-types:flexi-grid-frequency-slot;
+
+                leaf delta-power {
+                  type l0-types:power-in-dbm-or-null;
+                  description
+                    " Deviation from the reference carrier power 
+                    defined for the OMS.";
+                }
+              } // media channels list
+            } // media-channel-groups list
+          }
         }  // list amplifier-element
       }  // container operational
     }  // container amplifier
@@ -313,7 +347,7 @@ module ietf-optical-impairment-topology {
     leaf roadm-pdl {
       type l0-types:loss-in-db-or-null;
       description "Polarization Dependent Loss (PDL)";
-    }      
+    }
     leaf roadm-inband-crosstalk {
       type l0-types:decimal-2-digits-or-null;
       units "dB";
@@ -684,7 +718,7 @@ module ietf-optical-impairment-topology {
             "list of media channels represented as (n,m)";
 
           // this grouping add both n.m values
-          uses l0-types:flexi-grid-frequency-slot; 
+          uses l0-types:flexi-grid-frequency-slot;
 
           leaf otsi-group-ref {
             type leafref {

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -4,7 +4,7 @@ module ietf-optical-impairment-topology {
   namespace "urn:ietf:params:xml"
           + ":ns:yang:ietf-optical-impairment-topology";
 
-  prefix "optical-imp-topo";
+  prefix "oit";
 
   import ietf-network {
     prefix "nw";
@@ -87,7 +87,7 @@ module ietf-optical-impairment-topology {
 // this note
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2023-07-07 {
+  revision 2023-10-04 {
     description
       "Initial Version";
     reference
@@ -564,7 +564,7 @@ module ietf-optical-impairment-topology {
     }
   }
 
-  grouping power-param{
+  grouping power-param {
     description
       "optical power or PSD after the ROADM or after the out-voa";
     choice power-param {
@@ -662,7 +662,11 @@ module ietf-optical-impairment-topology {
   } // OTSiG grouping
 
   grouping media-channel-groups {
-    description "media channel groups";
+    description
+      "media channel groups.
+      
+      This grouping is not intended to be reused outside of this 
+      module.";
 
     container media-channel-groups {
       presence
@@ -684,7 +688,7 @@ module ietf-optical-impairment-topology {
 
           leaf otsi-group-ref {
             type leafref {
-              path "/nw:networks/nw:network/otsis/" +
+              path "../../../../../../../../otsis/" +
                   "otsi-group/otsi-group-id";
             }
             description
@@ -698,7 +702,7 @@ module ietf-optical-impairment-topology {
               OTSiG carried by this media channel.";
             leaf otsi-carrier-ref {
               type leafref {
-                path  "/nw:networks/nw:network/otsis/" +
+                path  "../../../../../../../../../otsis/" +
                       "otsi-group[otsi-group-id=current()" +
                       "/../../otsi-group-ref]/" +
                       "otsi/otsi-carrier-id" ;
@@ -709,7 +713,7 @@ module ietf-optical-impairment-topology {
             }
             leaf-list e2e-mc-path-ref {
               type leafref {
-                path  "/nw:networks/nw:network/otsis/" +
+                path  "../../../../../../../../../otsis/" +
                       "otsi-group[otsi-group-id=current()" +
                       "/../../otsi-group-ref]/" +
                       "otsi[otsi-carrier-id=current()" +
@@ -849,8 +853,8 @@ module ietf-optical-impairment-topology {
   }
 
   augment "/nw:networks/nw:network" {
-    when "nw:network-types/tet:te-topology" +
-         "/optical-imp-topo:optical-impairment-topology" {
+    when "./nw:network-types/tet:te-topology" +
+         "/oit:optical-impairment-topology" {
       description
         "This augment is only valid for Optical Impairment 
         topology.";
@@ -883,7 +887,7 @@ module ietf-optical-impairment-topology {
 
   augment "/nw:networks/nw:network/nw:node" {
     when "../nw:network-types/tet:te-topology" +
-         "/optical-imp-topo:optical-impairment-topology" {
+         "/oit:optical-impairment-topology" {
       description
         "This augment is only valid for Optical Impairment.";
     }
@@ -1066,7 +1070,7 @@ module ietf-optical-impairment-topology {
   augment "/nw:networks/nw:network/nt:link/tet:te"
         + "/tet:te-link-attributes"   {
     when "../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for Optical Impairment 
         topology.";
@@ -1084,7 +1088,7 @@ module ietf-optical-impairment-topology {
   augment "/nw:networks/nw:network/nw:node/tet:te"
         + "/tet:tunnel-termination-point" {
     when "../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for Impairment with
          non-sliceable transponder model";
@@ -1127,7 +1131,7 @@ module ietf-optical-impairment-topology {
   augment "/nw:networks/nw:network/nw:node/tet:te"
         + "/tet:tunnel-termination-point" {
     when "../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for optical impairment
        with sliceable transponder model";
@@ -1141,7 +1145,7 @@ module ietf-optical-impairment-topology {
   // Should this leaf be moved to te-topology?
   augment "/nw:networks/nw:network/nw:node/nt:termination-point" {
     when "../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for Optical Impairment 
         topology";
@@ -1163,7 +1167,7 @@ module ietf-optical-impairment-topology {
   augment "/nw:networks/nw:network/nw:node/tet:te"
         + "/tet:te-node-attributes" {
     when "../../../nw:network-types/tet:te-topology"
-       + "/optical-imp-topo:optical-impairment-topology" {
+       + "/oit:optical-impairment-topology" {
       description
         "This augment is only valid for Optical Impairment 
         topology";
@@ -1242,7 +1246,7 @@ module ietf-optical-impairment-topology {
   augment "/nw:networks/nw:network/nw:node/tet:te/"
         + "tet:information-source-entry/tet:connectivity-matrices"{
     when "../../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for Optical Impairment 
         topology ";
@@ -1266,7 +1270,7 @@ module ietf-optical-impairment-topology {
         + "tet:information-source-entry/tet:connectivity-matrices/"
         + "tet:connectivity-matrix" {
     when "../../../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for Optical Impairment
          topology ";
@@ -1288,7 +1292,7 @@ module ietf-optical-impairment-topology {
   augment "/nw:networks/nw:network/nw:node/tet:te/"
         + "tet:te-node-attributes/tet:connectivity-matrices" {
     when "../../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for Optical Impairment 
         topology ";
@@ -1312,7 +1316,7 @@ module ietf-optical-impairment-topology {
         + "tet:te-node-attributes/"
         + "tet:connectivity-matrices/tet:connectivity-matrix" {
     when "../../../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for 
         Optical Impairment topology ";
@@ -1334,7 +1338,7 @@ module ietf-optical-impairment-topology {
         + "tet:te-node-attributes/tet:connectivity-matrices/"
         + "tet:connectivity-matrix/tet:from" {
     when "../../../../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for 
         Optical Impairment topology ";
@@ -1346,8 +1350,8 @@ module ietf-optical-impairment-topology {
       when "derived-from-or-self(../../../../../../"
          + "nt:termination-point"
          + "[nt:tp-id=current()/../../tet:to/tet:tp-ref]/"
-         + "optical-imp-topo:protection-type,"
-         + "'optical-imp-topo:otsi-protection')" {
+         + "oit:protection-type,"
+         + "'oit:otsi-protection')" {
         description
           "This list applies only when the 'to' LTP for this 
           connectivity matrix entry supports individual OTSi(G) 
@@ -1389,7 +1393,7 @@ module ietf-optical-impairment-topology {
         + "tet:te-node-attributes/tet:connectivity-matrices/"
         + "tet:connectivity-matrix/tet:to" {
     when "../../../../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for 
         Optical Impairment topology ";
@@ -1401,8 +1405,8 @@ module ietf-optical-impairment-topology {
       when "derived-from-or-self(../../../../../../"
          + "nt:termination-point"
          + "[nt:tp-id=current()/../../tet:from/tet:tp-ref]/"
-         + "optical-imp-topo:protection-type,"
-         + "'optical-imp-topo:otsi-protection')" {
+         + "oit:protection-type,"
+         + "'oit:otsi-protection')" {
         description
           "This list applies only when the 'from' LTP for this 
           connectivity matrix entry supports individual OTSi(G) 
@@ -1444,7 +1448,7 @@ module ietf-optical-impairment-topology {
         + "tet:tunnel-termination-point/"
         + "tet:local-link-connectivities" {
     when "../../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
       "This augment is only valid for Optical Impairment topology ";
     }
@@ -1475,7 +1479,7 @@ module ietf-optical-impairment-topology {
         + "tet:local-link-connectivities/"
         + "tet:local-link-connectivity" {
     when "../../../../../nw:network-types/tet:te-topology/"
-       + "optical-imp-topo:optical-impairment-topology" {
+       + "oit:optical-impairment-topology" {
       description
         "This augment is only valid for
          Optical Impairment topology ";
@@ -1547,7 +1551,7 @@ module ietf-optical-impairment-topology {
     }
     list additional-ltp {
       when "derived-from-or-self(../../../tet:protection-type,"
-         + "'optical-imp-topo:otsi-protection')" {
+         + "'oit:otsi-protection')" {
         description
           "This list applies only to TTPs that support individual 
           OTSi(G) protection.";

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -1164,6 +1164,40 @@ module ietf-optical-impairment-topology {
     }
   }
 
+  augment "/nw:networks/nw:network/nw:node/nt:termination-point"
+        + "/tet:te" {
+    when "../../../nw:network-types/tet:te-topology/"
+       + "oit:optical-impairment-topology" {
+      description
+        "This augment is only valid for Optical Impairment 
+        topology";
+    }
+    description
+      "Augment TE attributes of an LTP";
+    
+    leaf inter-layer-sequence-number {
+      type uint32;
+      description
+        "The inter-layer-sequence-number (ILSN) is used to report 
+        additional connectivity constraints between a client layer 
+        Link Termination Point (LTP), such as a muxponder port, and 
+        the server layer Tunnel Termination Point (TTP).
+
+        A client service cannot be setup between two client layer 
+        LTPs which report different values of the ILSN.
+
+        This attribute is not reported when there are no additional 
+        connectivity constraints.
+        
+        Therefore, a client service can be setup when at least one 
+        of the two client layer LTPs does not report any ILSN or 
+        both client layer LTPs report the same ILSN value and the 
+        corresponding server layer TTPs have at least one common 
+        server-layer switching capability and at least one common 
+        client-layer switching capability.";
+    }
+  }
+
   augment "/nw:networks/nw:network/nw:node/tet:te"
         + "/tet:te-node-attributes" {
     when "../../../nw:network-types/tet:te-topology"

--- a/minutes/minutes-2023-10-03.md
+++ b/minutes/minutes-2023-10-03.md
@@ -1,0 +1,137 @@
+# YANG model for Optical Impairment aware Topology week (October 3rd,2023)
+
+
+****Attendees****
+- [] Dieter Beller
+- [x] Aihua Guo
+- [x] Esther Lerouzic
+- [x] Julien Meuric
+- [x] Italo Busi
+- [] Gert Grammel
+- [x] Gabriele Galimberti 
+- [x] Yuji Tochio
+- [x] Enrico Griseri
+- [x] Sergio Belotti
+- [] Victor Lopez
+- [] Haomian Zheng
+- [] Igor Bryskin
+- [] Dirk Schroetter
+- [] Brent Foster
+- [] Jiang Sun (CMCC)
+- [] Jan Kundrat
+- [] Eliana Vercelli
+- [] Jonathan Sadler
+- [x]Roberto Manzotti
+
+## Admin
+
+### Review APs (action point) Optical Impairment Topology YANG model
+
+####issue #124 "*Remove key from media channel list*"
+related to flexi-n value there is agreement to go ahead to delete the key statements from the media-channel-group/media-channel lists, making the flexi-n attribute optional.
+A possible issue without key is to have more elements with the same flexi-n and we cannot have 2 media-channel with the same flexi-n.
+
+**AP: Italo/Aihua** to have a look to possible YANG statement (e.g.unique statement) to overcome the issue
+
+Need to make some json examples and make the validation with yanglint.
+You cannot have two media channel in the same media channel group with the same flexi-n. See figure 5 in section 2.3.4
+
+       +--ro media-channel-groups!
+       |  +--ro media-channel-group* [i]
+       |     +--ro i                 int16
+       |     +--ro media-channels* []
+       |        +--ro flexi-n?          l0-types:flexi-n
+       |        +--ro flexi-m?          l0-types:flexi-m
+
+Need to check if "unique" statement is still valid when flexi-n is not present.
+Esther: flexi-n if it exists must be unique in the media-channel-group upper level list.
+
+
+### Review APs (action point) RFC9093-bis
+
+#### Issue #10 "Need for frequency and power range attributes also with Standard Mode"
+
+it seems that G.698.2 does not mandate transceivers to be tunable nor to support tunability for the whole frequency range between the minimum and maximum frequency.
+Then *it could be useful to add also to the standard mode the attributes used to report the frequency and power ranges supported by a given transceiver for a given application code*
+
+**AP: @Italo @Sergio: to check off-line with Q6 experts if our understanding is correct**
+
+#### Issue #21 "Review otu-type identities"  
+https://github.com/ietf-ccamp-wg/ietf-ccamp-layer0-types-ext-RFC9093-bis/issues/21
+
+**AP: @Aihua: to verify with Haomian if these otu identities are needed and where they are defined (some, but not all, are defined in G.Sup43)**
+
+### Closed Issues Optical Impairment Topology
+
+Issue #71 Issue tags for developpers 
+https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-optical-impairment-topology-yang/issues/71
+
+### Closed Issues RFC9093-bis
+
+Issue #24 "Clean-up groupings used only once"
+https://github.com/ietf-ccamp-wg/ietf-ccamp-layer0-types-ext-RFC9093-bis/issues/24
+
+
+### Next calls
+
+October 3rd 
+
+ 
+### Optical Impairment Topology YANG model
+
+#### #120  "Muxponders' configuration constraints"  
+https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-optical-impairment-topology-yang/issues/120
+
+Aihua presented some slides describing a proposal to solve the issue. https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-flexigrid-yang/files/11530989/Muxponder.Constraints.v3.pptx
+
+No comments during the presentation apart request for clarifications but the proposal seems a good way to solve the issue. No concerns were reaised.
+The agreement is to review the slides for next week and raise question if something appears not clear.
+
+## Today DISCUSSION
+
+#### #153  "Adding guideline for DGE representation"  
+https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-optical-impairment-topology-yang/issues/153
+
+The issue contains a proposal to represent a DGE.
+Italo asked what was the difference in the model wrt the amplifier and Esther replied 
+that amplifier has no power equalization wrt DGE.
+Italo asked also why not model DGE as OMS element and in fact Esther underlined 
+that ROADM and DGE terminate the OMS MCG and DGE act per channel. Amplifier instead is terminating OTS. These are ITU-T definitions.
+The basic proposal definition is to represent DGE as "2-degrees node terminating OMS MCGs".
+The basic concern is coming from Roberto who raised the point that in Cisco there are implementation where DGE is provided in ILA equipment.
+With respect the previous definition there are then some problems :
+* from traffic engineering prospective saying that a DGE MUST be a node with 2-degrees means that some xconnection configuration is needed, while if DGE is implemented as ILA there is no need
+for xconnection configuration. 
+* moreover a DGE as 2-degrees node should terminate OMS MCGs while in case a special development of ILA should represent DGE, this equipment would be a "new" type of OMS element terminting
+the OTS MCG but not the OMS MCG
+
+As summary we need to decide how to proceed : with the objection from Roberto it seems that DGE should be represented in 2 ways:
+1. as a 2-degrees te-node terminating the OMS MCGs
+2. as a new OMS element, not terminating the OMS MCG
+
+Esther observed that if we go with this decision, apart the impact on YANG model (need to define a new element in the OMS-element list) , 
+we need to be carefull with ITU-T definition of OMS since we introduce a new OMS element that , if implement DGE, should provide a demultiplexing of channels,
+that is in contraddiction of OMS definition.
+
+Post-meeting notes:
+Roberto provided more info on the ILA w/ DGE solution.
+This power equalization solution is not based on WSS filtering + VOA and re-muxing but is based on a different technology that we can call Gain shaping or Gain contouring.
+It is a concept similar to a GFF(Gain Flattering Filter) but with the capability to be dynamically configured in order to perfectly match (with some approximation)
+the gain profile required to achieve power equalization.
+Remember GFF works thank to the OCM(Optical Channel Monitoring) that looks at the channels in the spectrum w/o demultiplexing them.
+In this new technology implementation there is no WSS involved, the device is not capable to filter any carrier,do not perform any OMS termination, and therefore is also compliant
+with ITU-T definition.
+
+Roberto think we may need to account for both possible scenarios described in these notes:
+•	1 2-degrees te-node terminating OMS MCGs (based on WSS)
+•	1 new OMS element (based on Gain shaping) and not terminationg OMS MCG
+
+
+
+
+
+
+
+  
+  
+


### PR DESCRIPTION
Fixed relative paths in grouping media-channel-groups: see comment from Tom Petch in #144

Added muxponder constraints: fix #120

Added DGE attributes to amplifier element: see https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-optical-impairment-topology-yang/issues/153#issuecomment-1770362706

---

Pending merge of PR https://github.com/ietf-ccamp-wg/ietf-ccamp-layer0-types-ext-RFC9093-bis/pull/78

Co-authored-by: sergio belotti <sergio.belotti@nokia.com>