### PR TITLE
YANG updates for WG LC preparation:

### DIFF
--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -116,7 +116,7 @@ module: ietf-optical-impairment-topology
     |        |              +--ro out-of-band-osnr?
     |        |              |       snr
     |        |              +--ro tx-polarization-power-difference?
-    |        |              |       decimal-2
+    |        |              |       power-ratio
     |        |              +--ro polarization-skew?
     |        |              |       decimal64
     |        |              +--ro min-central-frequency?
@@ -194,22 +194,17 @@ module: ietf-optical-impairment-topology
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element* []
-                |           +--ro name?                        string
+                |           +--ro name?
+                |           |       string
+                |           +--ro type-variety?
+                |           |       string
                 |           +--ro is-dynamic-gain-equalyzer?
                 |           |       boolean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
-                |           +--ro actual-gain
-                |           |       l0-types:power-gain-or-null
-                |           +--ro tilt-target
-                |           |       l0-types:decimal-2-or-null
-                |           +--ro out-voa
-                |           |       l0-types:power-loss-or-null
-                |           +--ro in-voa
-                |           |       l0-types:power-loss-or-null
-                |           +--ro total-output-power
-                |           |       l0-types:power-dbm-or-null
+                |           +--ro stage-order?
+                |           |       uint8
                 |           +--ro power-param
                 |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
@@ -219,25 +214,49 @@ ull
                 |           |     +--:(power-spectral-density)
                 |           |        +--ro nominal-psd
                 |           |                l0-types:psd-or-null
-                |           +--ro raman-direction?
-                |           |       enumeration
-                |           +--ro raman-pump* []
-                |           |  +--ro frequency?
-                |           |  |       l0-types:frequency-thz
-                |           |  +--ro power?
-                |           |          l0-types:decimal-2-or-null
                 |           +--ro pdl?
                 |           |       l0-types:power-loss-or-null
-                |           +--ro media-channel-groups
-                |              +--ro media-channel-group* []
-                |                 +--ro media-channels* []
-                |                    +--ro flexi-n?
-                |                    |       l0-types:flexi-n
-                |                    +--ro flexi-m?
-                |                    |       l0-types:flexi-m
-                |                    +--ro delta-power?
-                |                            l0-types:power-ratio-or\
--null
+                |           +--ro (amplifier-element-type)
+                |              +--:(optical-amplifier)
+                |              |  +--ro optical-amplifier
+                |              |     +--ro actual-gain
+                |              |     |       l0-types:power-gain-or-\
+null
+                |              |     +--ro in-voa?
+                |              |     |       l0-types:power-loss-or-\
+null
+                |              |     +--ro out-voa?
+                |              |     |       l0-types:power-loss-or-\
+null
+                |              |     +--ro tilt-target
+                |              |     |       l0-types:decimal-2-or-n\
+ull
+                |              |     +--ro total-output-power
+                |              |     |       l0-types:power-dbm-or-n\
+ull
+                |              |     +--ro raman-direction?
+                |              |     |       enumeration
+                |              |     +--ro raman-pump* []
+                |              |        +--ro frequency?
+                |              |        |       l0-types:frequency-t\
+hz
+                |              |        +--ro power?
+                |              |                l0-types:decimal-2-o\
+r-null
+                |              +--:(dynamic-gain-equalyzer)
+                |                 +--ro dynamic-gain-equalyzer!
+                |                    +--ro media-channel-groups
+                |                       +--ro media-channel-group* []
+                |                          +--ro media-channels* []
+                |                             +--ro flexi-n?
+                |                             |       l0-types:flexi\
+-n
+                |                             +--ro flexi-m?
+                |                             |       l0-types:flexi\
+-m
+                |                             +--ro delta-power?
+                |                                     l0-types:power\
+-ratio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -42,15 +42,15 @@ module: ietf-optical-impairment-topology
     |        |        |     +--ro transceiver-tunability?
     |        |        |     |       frequency-ghz
     |        |        |     +--ro tx-channel-power-min?
-    |        |        |     |       power-in-dbm
+    |        |        |     |       power-dbm
     |        |        |     +--ro tx-channel-power-max?
-    |        |        |     |       power-in-dbm
+    |        |        |     |       power-dbm
     |        |        |     +--ro rx-channel-power-min?
-    |        |        |     |       power-in-dbm
+    |        |        |     |       power-dbm
     |        |        |     +--ro rx-channel-power-max?
-    |        |        |     |       power-in-dbm
+    |        |        |     |       power-dbm
     |        |        |     +--ro rx-total-power-max?
-    |        |        |             power-in-dbm
+    |        |        |             power-dbm
     |        |        +--:(explicit-mode)
     |        |           +--ro explicit-mode
     |        |              +--ro line-coding-bitrate?
@@ -70,20 +70,20 @@ module: ietf-optical-impairment-topology
     |        |              |  +--ro pmd-value        union
     |        |              |  +--ro penalty-value    union
     |        |              +--ro max-polarization-dependant-loss
-    |        |              |       loss-in-db-or-null
+    |        |              |       power-loss-or-null
     |        |              +--ro pdl-penalty* []
     |        |              |  +--ro pdl-value
-    |        |              |  |       loss-in-db-or-null
+    |        |              |  |       power-loss-or-null
     |        |              |  +--ro penalty-value    union
     |        |              +--ro available-modulation-type?
     |        |              |       identityref
     |        |              +--ro min-OSNR?
     |        |              |       snr
     |        |              +--ro rx-ref-channel-power?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro rx-channel-power-penalty* []
     |        |              |  +--ro rx-channel-power-value
-    |        |              |  |       power-in-dbm-or-null
+    |        |              |  |       power-dbm-or-null
     |        |              |  +--ro penalty-value             union
     |        |              +--ro min-Q-factor?
     |        |              |       int32
@@ -104,7 +104,7 @@ module: ietf-optical-impairment-topology
     |        |              +--ro out-of-band-osnr?
     |        |              |       snr
     |        |              +--ro tx-polarization-power-difference?
-    |        |              |       decimal-2-digits
+    |        |              |       decimal-2
     |        |              +--ro polarization-skew?
     |        |              |       decimal64
     |        |              +--ro min-central-frequency?
@@ -114,15 +114,15 @@ module: ietf-optical-impairment-topology
     |        |              +--ro transceiver-tunability?
     |        |              |       frequency-ghz
     |        |              +--ro tx-channel-power-min?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro tx-channel-power-max?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro rx-channel-power-min?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro rx-channel-power-max?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro rx-total-power-max?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro compatible-modes
     |        |                 +--ro supported-application-codes*
     |        |                 |       -> ../../../mode-id
@@ -130,12 +130,9 @@ module: ietf-optical-impairment-topology
     |        |                         -> ../../../mode-id
     |        +--ro configured-mode?               union
     |        +--ro line-coding-bitrate?           identityref
-    |        +--ro tx-channel-power?
-    |        |       power-in-dbm-or-null
-    |        +--ro rx-channel-power?
-    |        |       power-in-dbm-or-null
-    |        +--ro rx-total-power?
-    |        |       power-in-dbm-or-null
+    |        +--ro tx-channel-power?              power-dbm-or-null
+    |        +--ro rx-channel-power?              power-dbm-or-null
+    |        +--ro rx-total-power?                power-dbm-or-null
     |        +--ro outgoing-otsi
     |        |  +--ro otsi-group-ref?   leafref
     |        |  +--ro otsi-ref?         leafref
@@ -152,15 +149,11 @@ module: ietf-optical-impairment-topology
   augment /nw:networks/nw:network/nt:link/tet:te
             /tet:te-link-attributes:
     +--ro OMS-attributes
-       +--ro generalized-snr?                        l0-types:snr
-       +--ro equalization-mode?                      identityref
-       +--ro (power-param)?
-       |  +--:(channel-power)
-       |  |  +--ro nominal-carrier-power?
-       |  |          l0-types:power-in-dbm-or-null
-       |  +--:(power-spectral-density)
-       |     +--ro nominal-power-spectral-density?
-       |             l0-types:decimal-16-digits-or-null
+       +--ro generalized-snr?        l0-types:snr
+       +--ro equalization-mode?      identityref
+       +--ro power-param
+       |  +--ro nominal-carrier-power?   l0-types:power-dbm-or-null
+       |  +--ro nominal-psd?             l0-types:psd-or-null
        +--ro media-channel-groups!
        |  +--ro media-channel-group* []
        |     +--ro media-channels* []
@@ -170,7 +163,7 @@ module: ietf-optical-impairment-topology
        |        +--ro otsi-ref* []
        |        |  +--ro otsi-carrier-ref?   leafref
        |        |  +--ro e2e-mc-path-ref*    leafref
-       |        +--ro delta-power?      l0-types:gain-in-db-or-null
+       |        +--ro delta-power?      l0-types:power-ratio-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
@@ -189,43 +182,40 @@ module: ietf-optical-impairment-topology
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element* []
-                |           +--ro name?
-                |           |       string
+                |           +--ro name?                        string
                 |           +--ro is-dynamic-gain-equalyzer?
                 |           |       boolean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
                 |           +--ro actual-gain
-                |           |       l0-types:gain-in-db-or-null
+                |           |       l0-types:power-gain-or-null
                 |           +--ro tilt-target
-                |           |       l0-types:decimal-2-digits-or-null
+                |           |       l0-types:decimal-2-or-null
                 |           +--ro out-voa
-                |           |       l0-types:loss-in-db-or-null
+                |           |       l0-types:power-loss-or-null
                 |           +--ro in-voa
-                |           |       l0-types:loss-in-db-or-null
+                |           |       l0-types:power-loss-or-null
                 |           +--ro total-output-power
-                |           |       l0-types:power-in-dbm-or-null
-                |           +--ro (power-param)?
-                |           |  +--:(channel-power)
-                |           |  |  +--ro nominal-carrier-power?
-                |           |  |          l0-types:power-in-dbm-or-n\
+                |           |       l0-types:power-dbm-or-null
+                |           +--ro power-param
+                |           |  +--ro (power-param)
+                |           |     +--:(channel-power)
+                |           |     |  +--ro nominal-carrier-power
+                |           |     |          l0-types:power-dbm-or-n\
 ull
-                |           |  +--:(power-spectral-density)
-                |           |     +--ro nominal-power-spectral-densi\
-ty?
-                |           |             l0-types:decimal-16-digits\
--or-null
+                |           |     +--:(power-spectral-density)
+                |           |        +--ro nominal-psd
+                |           |                l0-types:psd-or-null
                 |           +--ro raman-direction?
                 |           |       enumeration
                 |           +--ro raman-pump* []
                 |           |  +--ro frequency?
                 |           |  |       l0-types:frequency-thz
                 |           |  +--ro power?
-                |           |          l0-types:decimal-2-digits-or-\
-null
+                |           |          l0-types:decimal-2-or-null
                 |           +--ro pdl?
-                |           |       l0-types:loss-in-db-or-null
+                |           |       l0-types:power-loss-or-null
                 |           +--ro media-channel-groups
                 |              +--ro media-channel-group* []
                 |                 +--ro media-channels* []
@@ -234,36 +224,32 @@ null
                 |                    +--ro flexi-m?
                 |                    |       l0-types:flexi-m
                 |                    +--ro delta-power?
-                |                            l0-types:gain-in-db-or-\
-null
+                |                            l0-types:power-ratio-or\
+-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string
                 |     +--ro length
-                |     |       l0-types:decimal-2-digits-or-null
+                |     |       l0-types:decimal-2-or-null
                 |     +--ro loss-coef
-                |     |       l0-types:decimal-2-digits-or-null
+                |     |       l0-types:decimal-2-or-null
                 |     +--ro total-loss
-                |     |       l0-types:loss-in-db-or-null
+                |     |       l0-types:power-loss-or-null
                 |     +--ro pmd?
-                |     |       l0-types:decimal-2-digits-or-null
+                |     |       l0-types:decimal-2-or-null
                 |     +--ro conn-in?
-                |     |       l0-types:loss-in-db-or-null
+                |     |       l0-types:power-loss-or-null
                 |     +--ro conn-out?
-                |             l0-types:loss-in-db-or-null
+                |             l0-types:power-loss-or-null
                 +--:(concentratedloss)
                    +--ro concentratedloss
-                      +--ro loss    l0-types:loss-in-db-or-null
+                      +--ro loss    l0-types:power-loss-or-null
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:tunnel-termination-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
        +--ro transponder-ref
        |       -> ../../../../transponders/transponder/transponder-id
        +--ro transceiver-ref    leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:tunnel-termination-point:
-    +--ro sliceable-transponder-list* [carrier-id]
-       +--ro carrier-id    uint32
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw protection-type?   identityref
   augment /nw:networks/nw:network/nw:node/nt:termination-point
@@ -281,13 +267,13 @@ null
           |     |  +--ro upper-frequency    frequency-thz
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?
-          |     |       l0-types:decimal-5-digits-or-null
+          |     |       l0-types:decimal-5-or-null
           |     +--ro roadm-pdl?
-          |     |       l0-types:loss-in-db-or-null
+          |     |       l0-types:power-loss-or-null
           |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types:decimal-2-digits-or-null
+          |     |       l0-types:decimal-2-or-null
           |     +--ro roadm-maxloss?
-          |             l0-types:loss-in-db-or-null
+          |             l0-types:power-loss-or-null
           +--:(roadm-add-path)
           |  +--ro roadm-add-path* []
           |     +--ro frequency-range
@@ -295,18 +281,18 @@ null
           |     |  +--ro upper-frequency    frequency-thz
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?
-          |     |       l0-types:decimal-5-digits-or-null
+          |     |       l0-types:decimal-5-or-null
           |     +--ro roadm-pdl?
-          |     |       l0-types:loss-in-db-or-null
+          |     |       l0-types:power-loss-or-null
           |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types:decimal-2-digits-or-null
+          |     |       l0-types:decimal-2-or-null
           |     +--ro roadm-maxloss?
-          |     |       l0-types:loss-in-db-or-null
+          |     |       l0-types:power-loss-or-null
           |     +--ro roadm-pmax?
-          |     |       l0-types:power-in-dbm-or-null
+          |     |       l0-types:power-dbm-or-null
           |     +--ro roadm-osnr?               l0-types:snr-or-null
           |     +--ro roadm-noise-figure?
-          |             l0-types:decimal-5-digits-or-null
+          |             l0-types:decimal-5-or-null
           +--:(roadm-drop-path)
              +--ro roadm-drop-path* []
                 +--ro frequency-range
@@ -314,26 +300,26 @@ null
                 |  +--ro upper-frequency    frequency-thz
                 +--ro roadm-pmd?                union
                 +--ro roadm-cd?
-                |       l0-types:decimal-5-digits-or-null
+                |       l0-types:decimal-5-or-null
                 +--ro roadm-pdl?
-                |       l0-types:loss-in-db-or-null
+                |       l0-types:power-loss-or-null
                 +--ro roadm-inband-crosstalk?
-                |       l0-types:decimal-2-digits-or-null
+                |       l0-types:decimal-2-or-null
                 +--ro roadm-maxloss?
-                |       l0-types:loss-in-db-or-null
+                |       l0-types:power-loss-or-null
                 +--ro roadm-minloss?
-                |       l0-types:loss-in-db-or-null
+                |       l0-types:power-loss-or-null
                 +--ro roadm-typloss?
-                |       l0-types:loss-in-db-or-null
+                |       l0-types:power-loss-or-null
                 +--ro roadm-pmin?
-                |       l0-types:power-in-dbm-or-null
+                |       l0-types:power-dbm-or-null
                 +--ro roadm-pmax?
-                |       l0-types:power-in-dbm-or-null
+                |       l0-types:power-dbm-or-null
                 +--ro roadm-ptyp?
-                |       l0-types:power-in-dbm-or-null
+                |       l0-types:power-dbm-or-null
                 +--ro roadm-osnr?               l0-types:snr-or-null
                 +--ro roadm-noise-figure?
-                        l0-types:decimal-5-digits-or-null
+                        l0-types:decimal-5-or-null
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:information-source-entry/tet:connectivity-matrices:
     +--ro roadm-path-impairments?   leafref

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -22,11 +22,23 @@ module: ietf-optical-impairment-topology
     |        +--ro transceiver-id                 uint32
     |        +--ro supported-modes!
     |        |  +--ro supported-mode* [mode-id]
-    |        |     +--ro mode-id                      string
+    |        |     +--ro mode-id                         string
     |        |     +--ro (mode)
     |        |        +--:(G.698.2)
-    |        |        |  +--ro standard-mode?         standard-mode
-    |        |        |  +--ro line-coding-bitrate*   identityref
+    |        |        |  +--ro standard-mode?
+    |        |        |  |       standard-mode
+    |        |        |  +--ro line-coding-bitrate*      identityref
+    |        |        |  +--ro min-central-frequency?
+    |        |        |  |       frequency-thz
+    |        |        |  +--ro max-central-frequency?
+    |        |        |  |       frequency-thz
+    |        |        |  +--ro transceiver-tunability?
+    |        |        |  |       frequency-ghz
+    |        |        |  +--ro tx-channel-power-min?     power-dbm
+    |        |        |  +--ro tx-channel-power-max?     power-dbm
+    |        |        |  +--ro rx-channel-power-min?     power-dbm
+    |        |        |  +--ro rx-channel-power-max?     power-dbm
+    |        |        |  +--ro rx-total-power-max?       power-dbm
     |        |        +--:(organizational-mode)
     |        |        |  +--ro organizational-mode
     |        |        |     +--ro operational-mode?

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -114,7 +114,7 @@ module: ietf-optical-impairment-topology
     |        |              +--ro out-of-band-osnr?
     |        |              |       snr
     |        |              +--ro tx-polarization-power-difference?
-    |        |              |       decimal-2
+    |        |              |       power-ratio
     |        |              +--ro polarization-skew?
     |        |              |       decimal64
     |        |              +--ro min-central-frequency?
@@ -192,22 +192,17 @@ module: ietf-optical-impairment-topology
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element* []
-                |           +--ro name?                        string
+                |           +--ro name?
+                |           |       string
+                |           +--ro type-variety?
+                |           |       string
                 |           +--ro is-dynamic-gain-equalyzer?
                 |           |       boolean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
-                |           +--ro actual-gain
-                |           |       l0-types:power-gain-or-null
-                |           +--ro tilt-target
-                |           |       l0-types:decimal-2-or-null
-                |           +--ro out-voa
-                |           |       l0-types:power-loss-or-null
-                |           +--ro in-voa
-                |           |       l0-types:power-loss-or-null
-                |           +--ro total-output-power
-                |           |       l0-types:power-dbm-or-null
+                |           +--ro stage-order?
+                |           |       uint8
                 |           +--ro power-param
                 |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
@@ -216,24 +211,39 @@ module: ietf-optical-impairment-topology
                 |           |     +--:(power-spectral-density)
                 |           |        +--ro nominal-psd
                 |           |                l0-types:psd-or-null
-                |           +--ro raman-direction?
-                |           |       enumeration
-                |           +--ro raman-pump* []
-                |           |  +--ro frequency?
-                |           |  |       l0-types:frequency-thz
-                |           |  +--ro power?
-                |           |          l0-types:decimal-2-or-null
                 |           +--ro pdl?
                 |           |       l0-types:power-loss-or-null
-                |           +--ro media-channel-groups
-                |              +--ro media-channel-group* []
-                |                 +--ro media-channels* []
-                |                    +--ro flexi-n?
-                |                    |       l0-types:flexi-n
-                |                    +--ro flexi-m?
-                |                    |       l0-types:flexi-m
-                |                    +--ro delta-power?
-                |                            l0-types:power-ratio-or-null
+                |           +--ro (amplifier-element-type)
+                |              +--:(optical-amplifier)
+                |              |  +--ro optical-amplifier
+                |              |     +--ro actual-gain
+                |              |     |       l0-types:power-gain-or-null
+                |              |     +--ro in-voa?
+                |              |     |       l0-types:power-loss-or-null
+                |              |     +--ro out-voa?
+                |              |     |       l0-types:power-loss-or-null
+                |              |     +--ro tilt-target
+                |              |     |       l0-types:decimal-2-or-null
+                |              |     +--ro total-output-power
+                |              |     |       l0-types:power-dbm-or-null
+                |              |     +--ro raman-direction?
+                |              |     |       enumeration
+                |              |     +--ro raman-pump* []
+                |              |        +--ro frequency?
+                |              |        |       l0-types:frequency-thz
+                |              |        +--ro power?
+                |              |                l0-types:decimal-2-or-null
+                |              +--:(dynamic-gain-equalyzer)
+                |                 +--ro dynamic-gain-equalyzer!
+                |                    +--ro media-channel-groups
+                |                       +--ro media-channel-group* []
+                |                          +--ro media-channels* []
+                |                             +--ro flexi-n?
+                |                             |       l0-types:flexi-n
+                |                             +--ro flexi-m?
+                |                             |       l0-types:flexi-m
+                |                             +--ro delta-power?
+                |                                     l0-types:power-ratio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -18,122 +18,7 @@ module: ietf-optical-impairment-topology
     |     +--ro supported-3r-mode?               enumeration
     |     +--ro transceiver* [transceiver-id]
     |        +--ro transceiver-id                 uint32
-    |        +--ro supported-modes!
-    |        |  +--ro supported-mode* [mode-id]
-    |        |     +--ro mode-id                      string
-    |        |     +--ro (mode)
-    |        |        +--:(G.698.2)
-    |        |        |  +--ro standard-mode?         standard-mode
-    |        |        |  +--ro line-coding-bitrate*   identityref
-    |        |        +--:(organizational-mode)
-    |        |        |  +--ro organizational-mode
-    |        |        |     +--ro operational-mode?
-    |        |        |     |       operational-mode
-    |        |        |     +--ro organization-identifier?
-    |        |        |     |       organization-identifier
-    |        |        |     +--ro line-coding-bitrate*
-    |        |        |     |       identityref
-    |        |        |     +--ro min-central-frequency?
-    |        |        |     |       frequency-thz
-    |        |        |     +--ro max-central-frequency?
-    |        |        |     |       frequency-thz
-    |        |        |     +--ro transceiver-tunability?
-    |        |        |     |       frequency-ghz
-    |        |        |     +--ro tx-channel-power-min?
-    |        |        |     |       power-in-dbm
-    |        |        |     +--ro tx-channel-power-max?
-    |        |        |     |       power-in-dbm
-    |        |        |     +--ro rx-channel-power-min?
-    |        |        |     |       power-in-dbm
-    |        |        |     +--ro rx-channel-power-max?
-    |        |        |     |       power-in-dbm
-    |        |        |     +--ro rx-total-power-max?
-    |        |        |             power-in-dbm
-    |        |        +--:(explicit-mode)
-    |        |           +--ro explicit-mode
-    |        |              +--ro line-coding-bitrate?
-    |        |              |       identityref
-    |        |              +--ro bitrate?
-    |        |              |       uint16
-    |        |              +--ro max-diff-group-delay?
-    |        |              |       uint32
-    |        |              +--ro max-chromatic-dispersion?
-    |        |              |       decimal64
-    |        |              +--ro cd-penalty* []
-    |        |              |  +--ro cd-value         union
-    |        |              |  +--ro penalty-value    union
-    |        |              +--ro max-polarization-mode-dispersion?
-    |        |              |       decimal64
-    |        |              +--ro pmd-penalty* []
-    |        |              |  +--ro pmd-value        union
-    |        |              |  +--ro penalty-value    union
-    |        |              +--ro max-polarization-dependant-loss
-    |        |              |       loss-in-db-or-null
-    |        |              +--ro pdl-penalty* []
-    |        |              |  +--ro pdl-value
-    |        |              |  |       loss-in-db-or-null
-    |        |              |  +--ro penalty-value    union
-    |        |              +--ro available-modulation-type?
-    |        |              |       identityref
-    |        |              +--ro min-OSNR?
-    |        |              |       snr
-    |        |              +--ro rx-ref-channel-power?
-    |        |              |       power-in-dbm
-    |        |              +--ro rx-channel-power-penalty* []
-    |        |              |  +--ro rx-channel-power-value
-    |        |              |  |       power-in-dbm-or-null
-    |        |              |  +--ro penalty-value             union
-    |        |              +--ro min-Q-factor?
-    |        |              |       int32
-    |        |              +--ro available-baud-rate?
-    |        |              |       uint32
-    |        |              +--ro roll-off?
-    |        |              |       decimal64
-    |        |              +--ro min-carrier-spacing?
-    |        |              |       frequency-ghz
-    |        |              +--ro available-fec-type?
-    |        |              |       identityref
-    |        |              +--ro fec-code-rate?
-    |        |              |       decimal64
-    |        |              +--ro fec-threshold?
-    |        |              |       decimal64
-    |        |              +--ro in-band-osnr?
-    |        |              |       snr
-    |        |              +--ro out-of-band-osnr?
-    |        |              |       snr
-    |        |              +--ro tx-polarization-power-difference?
-    |        |              |       decimal-2-digits
-    |        |              +--ro polarization-skew?
-    |        |              |       decimal64
-    |        |              +--ro min-central-frequency?
-    |        |              |       frequency-thz
-    |        |              +--ro max-central-frequency?
-    |        |              |       frequency-thz
-    |        |              +--ro transceiver-tunability?
-    |        |              |       frequency-ghz
-    |        |              +--ro tx-channel-power-min?
-    |        |              |       power-in-dbm
-    |        |              +--ro tx-channel-power-max?
-    |        |              |       power-in-dbm
-    |        |              +--ro rx-channel-power-min?
-    |        |              |       power-in-dbm
-    |        |              +--ro rx-channel-power-max?
-    |        |              |       power-in-dbm
-    |        |              +--ro rx-total-power-max?
-    |        |              |       power-in-dbm
-    |        |              +--ro compatible-modes
-    |        |                 +--ro supported-application-codes*
-    |        |                 |       -> ../../../mode-id
-    |        |                 +--ro supported-organizational-modes*
-    |        |                         -> ../../../mode-id
     |        +--ro configured-mode?               union
-    |        +--ro line-coding-bitrate?           identityref
-    |        +--ro tx-channel-power?
-    |        |       power-in-dbm-or-null
-    |        +--ro rx-channel-power?
-    |        |       power-in-dbm-or-null
-    |        +--ro rx-total-power?
-    |        |       power-in-dbm-or-null
     |        +--ro outgoing-otsi
     |        |  +--ro otsi-group-ref?   leafref
     |        |  +--ro otsi-ref?         leafref
@@ -155,13 +40,11 @@ module: ietf-optical-impairment-topology
        +--ro power-param
        |  +--ro nominal-carrier-power?
        |  |       l0-types:power-in-dbm-or-null
-       |  +--ro nominal-power-spectral-density?
+       |  +--ro nominal-psd?
        |          l0-types:power-spectral-density-or-null
        +--ro media-channel-groups!
        |  +--ro media-channel-group* []
        |     +--ro media-channels* []
-       |        +--ro flexi-n?          l0-types:flexi-n
-       |        +--ro flexi-m?          l0-types:flexi-m
        |        +--ro otsi-group-ref?   leafref
        |        +--ro otsi-ref* []
        |        |  +--ro otsi-carrier-ref?   leafref
@@ -189,8 +72,6 @@ module: ietf-optical-impairment-topology
                 |           +--ro is-dynamic-gain-equalyzer?
                 |           |       boolean
                 |           +--ro frequency-range
-                |           |  +--ro lower-frequency    frequency-thz
-                |           |  +--ro upper-frequency    frequency-thz
                 |           +--ro actual-gain
                 |           |       l0-types:gain-in-db-or-null
                 |           +--ro tilt-target
@@ -202,12 +83,12 @@ module: ietf-optical-impairment-topology
                 |           +--ro total-output-power
                 |           |       l0-types:power-in-dbm-or-null
                 |           +--ro power-param
-                |           |  +--ro (power-param)?
+                |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
-                |           |     |  +--ro nominal-carrier-power?
+                |           |     |  +--ro nominal-carrier-power
                 |           |     |          l0-types:power-in-dbm-or-null
                 |           |     +--:(power-spectral-density)
-                |           |        +--ro nominal-power-spectral-density?
+                |           |        +--ro nominal-psd
                 |           |                l0-types:power-spectral-density-or-null
                 |           +--ro raman-direction?
                 |           |       enumeration
@@ -221,10 +102,6 @@ module: ietf-optical-impairment-topology
                 |           +--ro media-channel-groups
                 |              +--ro media-channel-group* []
                 |                 +--ro media-channels* []
-                |                    +--ro flexi-n?
-                |                    |       l0-types:flexi-n
-                |                    +--ro flexi-m?
-                |                    |       l0-types:flexi-m
                 |                    +--ro delta-power?
                 |                            l0-types:ratio-in-db-or-null
                 +--:(fiber)
@@ -264,8 +141,6 @@ module: ietf-optical-impairment-topology
           +--:(roadm-express-path)
           |  +--ro roadm-express-path* []
           |     +--ro frequency-range
-          |     |  +--ro lower-frequency    frequency-thz
-          |     |  +--ro upper-frequency    frequency-thz
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?
           |     |       l0-types:decimal-5-digits-or-null
@@ -278,8 +153,6 @@ module: ietf-optical-impairment-topology
           +--:(roadm-add-path)
           |  +--ro roadm-add-path* []
           |     +--ro frequency-range
-          |     |  +--ro lower-frequency    frequency-thz
-          |     |  +--ro upper-frequency    frequency-thz
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?
           |     |       l0-types:decimal-5-digits-or-null
@@ -297,8 +170,6 @@ module: ietf-optical-impairment-topology
           +--:(roadm-drop-path)
              +--ro roadm-drop-path* []
                 +--ro frequency-range
-                |  +--ro lower-frequency    frequency-thz
-                |  +--ro upper-frequency    frequency-thz
                 +--ro roadm-pmd?                union
                 +--ro roadm-cd?
                 |       l0-types:decimal-5-digits-or-null

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -150,15 +150,13 @@ module: ietf-optical-impairment-topology
   augment /nw:networks/nw:network/nt:link/tet:te
             /tet:te-link-attributes:
     +--ro OMS-attributes
-       +--ro generalized-snr?                        l0-types:snr
-       +--ro equalization-mode?                      identityref
-       +--ro (power-param)?
-       |  +--:(channel-power)
-       |  |  +--ro nominal-carrier-power?
-       |  |          l0-types:power-in-dbm-or-null
-       |  +--:(power-spectral-density)
-       |     +--ro nominal-power-spectral-density?
-       |             l0-types:decimal-16-digits-or-null
+       +--ro generalized-snr?        l0-types:snr
+       +--ro equalization-mode?      identityref
+       +--ro power-param
+       |  +--ro nominal-carrier-power?
+       |  |       l0-types:power-in-dbm-or-null
+       |  +--ro nominal-power-spectral-density?
+       |          l0-types:power-spectral-density-or-null
        +--ro media-channel-groups!
        |  +--ro media-channel-group* []
        |     +--ro media-channels* []
@@ -168,7 +166,7 @@ module: ietf-optical-impairment-topology
        |        +--ro otsi-ref* []
        |        |  +--ro otsi-carrier-ref?   leafref
        |        |  +--ro e2e-mc-path-ref*    leafref
-       |        +--ro delta-power?      l0-types:gain-in-db-or-null
+       |        +--ro delta-power?      l0-types:ratio-in-db-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
@@ -187,8 +185,7 @@ module: ietf-optical-impairment-topology
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element* []
-                |           +--ro name?
-                |           |       string
+                |           +--ro name?                        string
                 |           +--ro is-dynamic-gain-equalyzer?
                 |           |       boolean
                 |           +--ro frequency-range
@@ -204,13 +201,14 @@ module: ietf-optical-impairment-topology
                 |           |       l0-types:loss-in-db-or-null
                 |           +--ro total-output-power
                 |           |       l0-types:power-in-dbm-or-null
-                |           +--ro (power-param)?
-                |           |  +--:(channel-power)
-                |           |  |  +--ro nominal-carrier-power?
-                |           |  |          l0-types:power-in-dbm-or-null
-                |           |  +--:(power-spectral-density)
-                |           |     +--ro nominal-power-spectral-density?
-                |           |             l0-types:decimal-16-digits-or-null
+                |           +--ro power-param
+                |           |  +--ro (power-param)?
+                |           |     +--:(channel-power)
+                |           |     |  +--ro nominal-carrier-power?
+                |           |     |          l0-types:power-in-dbm-or-null
+                |           |     +--:(power-spectral-density)
+                |           |        +--ro nominal-power-spectral-density?
+                |           |                l0-types:power-spectral-density-or-null
                 |           +--ro raman-direction?
                 |           |       enumeration
                 |           +--ro raman-pump* []
@@ -228,7 +226,7 @@ module: ietf-optical-impairment-topology
                 |                    +--ro flexi-m?
                 |                    |       l0-types:flexi-m
                 |                    +--ro delta-power?
-                |                            l0-types:gain-in-db-or-null
+                |                            l0-types:ratio-in-db-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string
@@ -253,10 +251,6 @@ module: ietf-optical-impairment-topology
        +--ro transponder-ref
        |       -> ../../../../transponders/transponder/transponder-id
        +--ro transceiver-ref    leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:tunnel-termination-point:
-    +--ro sliceable-transponder-list* [carrier-id]
-       +--ro carrier-id    uint32
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw protection-type?   identityref
   augment /nw:networks/nw:network/nw:node/nt:termination-point

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -18,7 +18,122 @@ module: ietf-optical-impairment-topology
     |     +--ro supported-3r-mode?               enumeration
     |     +--ro transceiver* [transceiver-id]
     |        +--ro transceiver-id                 uint32
+    |        +--ro supported-modes!
+    |        |  +--ro supported-mode* [mode-id]
+    |        |     +--ro mode-id                      string
+    |        |     +--ro (mode)
+    |        |        +--:(G.698.2)
+    |        |        |  +--ro standard-mode?         standard-mode
+    |        |        |  +--ro line-coding-bitrate*   identityref
+    |        |        +--:(organizational-mode)
+    |        |        |  +--ro organizational-mode
+    |        |        |     +--ro operational-mode?
+    |        |        |     |       operational-mode
+    |        |        |     +--ro organization-identifier?
+    |        |        |     |       organization-identifier
+    |        |        |     +--ro line-coding-bitrate*
+    |        |        |     |       identityref
+    |        |        |     +--ro min-central-frequency?
+    |        |        |     |       frequency-thz
+    |        |        |     +--ro max-central-frequency?
+    |        |        |     |       frequency-thz
+    |        |        |     +--ro transceiver-tunability?
+    |        |        |     |       frequency-ghz
+    |        |        |     +--ro tx-channel-power-min?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro tx-channel-power-max?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro rx-channel-power-min?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro rx-channel-power-max?
+    |        |        |     |       power-in-dbm
+    |        |        |     +--ro rx-total-power-max?
+    |        |        |             power-in-dbm
+    |        |        +--:(explicit-mode)
+    |        |           +--ro explicit-mode
+    |        |              +--ro line-coding-bitrate?
+    |        |              |       identityref
+    |        |              +--ro bitrate?
+    |        |              |       uint16
+    |        |              +--ro max-diff-group-delay?
+    |        |              |       uint32
+    |        |              +--ro max-chromatic-dispersion?
+    |        |              |       decimal64
+    |        |              +--ro cd-penalty* []
+    |        |              |  +--ro cd-value         union
+    |        |              |  +--ro penalty-value    union
+    |        |              +--ro max-polarization-mode-dispersion?
+    |        |              |       decimal64
+    |        |              +--ro pmd-penalty* []
+    |        |              |  +--ro pmd-value        union
+    |        |              |  +--ro penalty-value    union
+    |        |              +--ro max-polarization-dependant-loss
+    |        |              |       loss-in-db-or-null
+    |        |              +--ro pdl-penalty* []
+    |        |              |  +--ro pdl-value
+    |        |              |  |       loss-in-db-or-null
+    |        |              |  +--ro penalty-value    union
+    |        |              +--ro available-modulation-type?
+    |        |              |       identityref
+    |        |              +--ro min-OSNR?
+    |        |              |       snr
+    |        |              +--ro rx-ref-channel-power?
+    |        |              |       power-in-dbm
+    |        |              +--ro rx-channel-power-penalty* []
+    |        |              |  +--ro rx-channel-power-value
+    |        |              |  |       power-in-dbm-or-null
+    |        |              |  +--ro penalty-value             union
+    |        |              +--ro min-Q-factor?
+    |        |              |       int32
+    |        |              +--ro available-baud-rate?
+    |        |              |       uint32
+    |        |              +--ro roll-off?
+    |        |              |       decimal64
+    |        |              +--ro min-carrier-spacing?
+    |        |              |       frequency-ghz
+    |        |              +--ro available-fec-type?
+    |        |              |       identityref
+    |        |              +--ro fec-code-rate?
+    |        |              |       decimal64
+    |        |              +--ro fec-threshold?
+    |        |              |       decimal64
+    |        |              +--ro in-band-osnr?
+    |        |              |       snr
+    |        |              +--ro out-of-band-osnr?
+    |        |              |       snr
+    |        |              +--ro tx-polarization-power-difference?
+    |        |              |       decimal-2-digits
+    |        |              +--ro polarization-skew?
+    |        |              |       decimal64
+    |        |              +--ro min-central-frequency?
+    |        |              |       frequency-thz
+    |        |              +--ro max-central-frequency?
+    |        |              |       frequency-thz
+    |        |              +--ro transceiver-tunability?
+    |        |              |       frequency-ghz
+    |        |              +--ro tx-channel-power-min?
+    |        |              |       power-in-dbm
+    |        |              +--ro tx-channel-power-max?
+    |        |              |       power-in-dbm
+    |        |              +--ro rx-channel-power-min?
+    |        |              |       power-in-dbm
+    |        |              +--ro rx-channel-power-max?
+    |        |              |       power-in-dbm
+    |        |              +--ro rx-total-power-max?
+    |        |              |       power-in-dbm
+    |        |              +--ro compatible-modes
+    |        |                 +--ro supported-application-codes*
+    |        |                 |       -> ../../../mode-id
+    |        |                 +--ro supported-organizational-modes*
+    |        |                         -> ../../../mode-id
     |        +--ro configured-mode?               union
+    |        +--ro line-coding-bitrate?           identityref
+    |        +--ro tx-channel-power?
+    |        |       power-in-dbm-or-null
+    |        +--ro rx-channel-power?
+    |        |       power-in-dbm-or-null
+    |        +--ro rx-total-power?
+    |        |       power-in-dbm-or-null
     |        +--ro outgoing-otsi
     |        |  +--ro otsi-group-ref?   leafref
     |        |  +--ro otsi-ref?         leafref
@@ -45,6 +160,8 @@ module: ietf-optical-impairment-topology
        +--ro media-channel-groups!
        |  +--ro media-channel-group* []
        |     +--ro media-channels* []
+       |        +--ro flexi-n?          l0-types:flexi-n
+       |        +--ro flexi-m?          l0-types:flexi-m
        |        +--ro otsi-group-ref?   leafref
        |        +--ro otsi-ref* []
        |        |  +--ro otsi-carrier-ref?   leafref
@@ -72,6 +189,8 @@ module: ietf-optical-impairment-topology
                 |           +--ro is-dynamic-gain-equalyzer?
                 |           |       boolean
                 |           +--ro frequency-range
+                |           |  +--ro lower-frequency    frequency-thz
+                |           |  +--ro upper-frequency    frequency-thz
                 |           +--ro actual-gain
                 |           |       l0-types:gain-in-db-or-null
                 |           +--ro tilt-target
@@ -102,6 +221,10 @@ module: ietf-optical-impairment-topology
                 |           +--ro media-channel-groups
                 |              +--ro media-channel-group* []
                 |                 +--ro media-channels* []
+                |                    +--ro flexi-n?
+                |                    |       l0-types:flexi-n
+                |                    +--ro flexi-m?
+                |                    |       l0-types:flexi-m
                 |                    +--ro delta-power?
                 |                            l0-types:ratio-in-db-or-null
                 +--:(fiber)
@@ -141,6 +264,8 @@ module: ietf-optical-impairment-topology
           +--:(roadm-express-path)
           |  +--ro roadm-express-path* []
           |     +--ro frequency-range
+          |     |  +--ro lower-frequency    frequency-thz
+          |     |  +--ro upper-frequency    frequency-thz
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?
           |     |       l0-types:decimal-5-digits-or-null
@@ -153,6 +278,8 @@ module: ietf-optical-impairment-topology
           +--:(roadm-add-path)
           |  +--ro roadm-add-path* []
           |     +--ro frequency-range
+          |     |  +--ro lower-frequency    frequency-thz
+          |     |  +--ro upper-frequency    frequency-thz
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?
           |     |       l0-types:decimal-5-digits-or-null
@@ -170,6 +297,8 @@ module: ietf-optical-impairment-topology
           +--:(roadm-drop-path)
              +--ro roadm-drop-path* []
                 +--ro frequency-range
+                |  +--ro lower-frequency    frequency-thz
+                |  +--ro upper-frequency    frequency-thz
                 +--ro roadm-pmd?                union
                 +--ro roadm-cd?
                 |       l0-types:decimal-5-digits-or-null
@@ -245,3 +374,4 @@ module: ietf-optical-impairment-topology
        |       -> ../../../../../../nt:termination-point/tp-id
        +--ro add-path-impairments?    leafref
        +--ro drop-path-impairments?   leafref
+

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -20,11 +20,23 @@ module: ietf-optical-impairment-topology
     |        +--ro transceiver-id                 uint32
     |        +--ro supported-modes!
     |        |  +--ro supported-mode* [mode-id]
-    |        |     +--ro mode-id                      string
+    |        |     +--ro mode-id                         string
     |        |     +--ro (mode)
     |        |        +--:(G.698.2)
-    |        |        |  +--ro standard-mode?         standard-mode
-    |        |        |  +--ro line-coding-bitrate*   identityref
+    |        |        |  +--ro standard-mode?
+    |        |        |  |       standard-mode
+    |        |        |  +--ro line-coding-bitrate*      identityref
+    |        |        |  +--ro min-central-frequency?
+    |        |        |  |       frequency-thz
+    |        |        |  +--ro max-central-frequency?
+    |        |        |  |       frequency-thz
+    |        |        |  +--ro transceiver-tunability?
+    |        |        |  |       frequency-ghz
+    |        |        |  +--ro tx-channel-power-min?     power-dbm
+    |        |        |  +--ro tx-channel-power-max?     power-dbm
+    |        |        |  +--ro rx-channel-power-min?     power-dbm
+    |        |        |  +--ro rx-channel-power-max?     power-dbm
+    |        |        |  +--ro rx-total-power-max?       power-dbm
     |        |        +--:(organizational-mode)
     |        |        |  +--ro organizational-mode
     |        |        |     +--ro operational-mode?

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -40,15 +40,15 @@ module: ietf-optical-impairment-topology
     |        |        |     +--ro transceiver-tunability?
     |        |        |     |       frequency-ghz
     |        |        |     +--ro tx-channel-power-min?
-    |        |        |     |       power-in-dbm
+    |        |        |     |       power-dbm
     |        |        |     +--ro tx-channel-power-max?
-    |        |        |     |       power-in-dbm
+    |        |        |     |       power-dbm
     |        |        |     +--ro rx-channel-power-min?
-    |        |        |     |       power-in-dbm
+    |        |        |     |       power-dbm
     |        |        |     +--ro rx-channel-power-max?
-    |        |        |     |       power-in-dbm
+    |        |        |     |       power-dbm
     |        |        |     +--ro rx-total-power-max?
-    |        |        |             power-in-dbm
+    |        |        |             power-dbm
     |        |        +--:(explicit-mode)
     |        |           +--ro explicit-mode
     |        |              +--ro line-coding-bitrate?
@@ -68,20 +68,20 @@ module: ietf-optical-impairment-topology
     |        |              |  +--ro pmd-value        union
     |        |              |  +--ro penalty-value    union
     |        |              +--ro max-polarization-dependant-loss
-    |        |              |       loss-in-db-or-null
+    |        |              |       power-loss-or-null
     |        |              +--ro pdl-penalty* []
     |        |              |  +--ro pdl-value
-    |        |              |  |       loss-in-db-or-null
+    |        |              |  |       power-loss-or-null
     |        |              |  +--ro penalty-value    union
     |        |              +--ro available-modulation-type?
     |        |              |       identityref
     |        |              +--ro min-OSNR?
     |        |              |       snr
     |        |              +--ro rx-ref-channel-power?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro rx-channel-power-penalty* []
     |        |              |  +--ro rx-channel-power-value
-    |        |              |  |       power-in-dbm-or-null
+    |        |              |  |       power-dbm-or-null
     |        |              |  +--ro penalty-value             union
     |        |              +--ro min-Q-factor?
     |        |              |       int32
@@ -102,7 +102,7 @@ module: ietf-optical-impairment-topology
     |        |              +--ro out-of-band-osnr?
     |        |              |       snr
     |        |              +--ro tx-polarization-power-difference?
-    |        |              |       decimal-2-digits
+    |        |              |       decimal-2
     |        |              +--ro polarization-skew?
     |        |              |       decimal64
     |        |              +--ro min-central-frequency?
@@ -112,15 +112,15 @@ module: ietf-optical-impairment-topology
     |        |              +--ro transceiver-tunability?
     |        |              |       frequency-ghz
     |        |              +--ro tx-channel-power-min?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro tx-channel-power-max?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro rx-channel-power-min?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro rx-channel-power-max?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro rx-total-power-max?
-    |        |              |       power-in-dbm
+    |        |              |       power-dbm
     |        |              +--ro compatible-modes
     |        |                 +--ro supported-application-codes*
     |        |                 |       -> ../../../mode-id
@@ -128,12 +128,9 @@ module: ietf-optical-impairment-topology
     |        |                         -> ../../../mode-id
     |        +--ro configured-mode?               union
     |        +--ro line-coding-bitrate?           identityref
-    |        +--ro tx-channel-power?
-    |        |       power-in-dbm-or-null
-    |        +--ro rx-channel-power?
-    |        |       power-in-dbm-or-null
-    |        +--ro rx-total-power?
-    |        |       power-in-dbm-or-null
+    |        +--ro tx-channel-power?              power-dbm-or-null
+    |        +--ro rx-channel-power?              power-dbm-or-null
+    |        +--ro rx-total-power?                power-dbm-or-null
     |        +--ro outgoing-otsi
     |        |  +--ro otsi-group-ref?   leafref
     |        |  +--ro otsi-ref?         leafref
@@ -153,10 +150,8 @@ module: ietf-optical-impairment-topology
        +--ro generalized-snr?        l0-types:snr
        +--ro equalization-mode?      identityref
        +--ro power-param
-       |  +--ro nominal-carrier-power?
-       |  |       l0-types:power-in-dbm-or-null
-       |  +--ro nominal-psd?
-       |          l0-types:power-spectral-density-or-null
+       |  +--ro nominal-carrier-power?   l0-types:power-dbm-or-null
+       |  +--ro nominal-psd?             l0-types:psd-or-null
        +--ro media-channel-groups!
        |  +--ro media-channel-group* []
        |     +--ro media-channels* []
@@ -166,7 +161,7 @@ module: ietf-optical-impairment-topology
        |        +--ro otsi-ref* []
        |        |  +--ro otsi-carrier-ref?   leafref
        |        |  +--ro e2e-mc-path-ref*    leafref
-       |        +--ro delta-power?      l0-types:ratio-in-db-or-null
+       |        +--ro delta-power?      l0-types:power-ratio-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
@@ -192,32 +187,32 @@ module: ietf-optical-impairment-topology
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
                 |           +--ro actual-gain
-                |           |       l0-types:gain-in-db-or-null
+                |           |       l0-types:power-gain-or-null
                 |           +--ro tilt-target
-                |           |       l0-types:decimal-2-digits-or-null
+                |           |       l0-types:decimal-2-or-null
                 |           +--ro out-voa
-                |           |       l0-types:loss-in-db-or-null
+                |           |       l0-types:power-loss-or-null
                 |           +--ro in-voa
-                |           |       l0-types:loss-in-db-or-null
+                |           |       l0-types:power-loss-or-null
                 |           +--ro total-output-power
-                |           |       l0-types:power-in-dbm-or-null
+                |           |       l0-types:power-dbm-or-null
                 |           +--ro power-param
                 |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
                 |           |     |  +--ro nominal-carrier-power
-                |           |     |          l0-types:power-in-dbm-or-null
+                |           |     |          l0-types:power-dbm-or-null
                 |           |     +--:(power-spectral-density)
                 |           |        +--ro nominal-psd
-                |           |                l0-types:power-spectral-density-or-null
+                |           |                l0-types:psd-or-null
                 |           +--ro raman-direction?
                 |           |       enumeration
                 |           +--ro raman-pump* []
                 |           |  +--ro frequency?
                 |           |  |       l0-types:frequency-thz
                 |           |  +--ro power?
-                |           |          l0-types:decimal-2-digits-or-null
+                |           |          l0-types:decimal-2-or-null
                 |           +--ro pdl?
-                |           |       l0-types:loss-in-db-or-null
+                |           |       l0-types:power-loss-or-null
                 |           +--ro media-channel-groups
                 |              +--ro media-channel-group* []
                 |                 +--ro media-channels* []
@@ -226,25 +221,25 @@ module: ietf-optical-impairment-topology
                 |                    +--ro flexi-m?
                 |                    |       l0-types:flexi-m
                 |                    +--ro delta-power?
-                |                            l0-types:ratio-in-db-or-null
+                |                            l0-types:power-ratio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string
                 |     +--ro length
-                |     |       l0-types:decimal-2-digits-or-null
+                |     |       l0-types:decimal-2-or-null
                 |     +--ro loss-coef
-                |     |       l0-types:decimal-2-digits-or-null
+                |     |       l0-types:decimal-2-or-null
                 |     +--ro total-loss
-                |     |       l0-types:loss-in-db-or-null
+                |     |       l0-types:power-loss-or-null
                 |     +--ro pmd?
-                |     |       l0-types:decimal-2-digits-or-null
+                |     |       l0-types:decimal-2-or-null
                 |     +--ro conn-in?
-                |     |       l0-types:loss-in-db-or-null
+                |     |       l0-types:power-loss-or-null
                 |     +--ro conn-out?
-                |             l0-types:loss-in-db-or-null
+                |             l0-types:power-loss-or-null
                 +--:(concentratedloss)
                    +--ro concentratedloss
-                      +--ro loss    l0-types:loss-in-db-or-null
+                      +--ro loss    l0-types:power-loss-or-null
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:tunnel-termination-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
@@ -268,13 +263,13 @@ module: ietf-optical-impairment-topology
           |     |  +--ro upper-frequency    frequency-thz
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?
-          |     |       l0-types:decimal-5-digits-or-null
+          |     |       l0-types:decimal-5-or-null
           |     +--ro roadm-pdl?
-          |     |       l0-types:loss-in-db-or-null
+          |     |       l0-types:power-loss-or-null
           |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types:decimal-2-digits-or-null
+          |     |       l0-types:decimal-2-or-null
           |     +--ro roadm-maxloss?
-          |             l0-types:loss-in-db-or-null
+          |             l0-types:power-loss-or-null
           +--:(roadm-add-path)
           |  +--ro roadm-add-path* []
           |     +--ro frequency-range
@@ -282,18 +277,18 @@ module: ietf-optical-impairment-topology
           |     |  +--ro upper-frequency    frequency-thz
           |     +--ro roadm-pmd?                union
           |     +--ro roadm-cd?
-          |     |       l0-types:decimal-5-digits-or-null
+          |     |       l0-types:decimal-5-or-null
           |     +--ro roadm-pdl?
-          |     |       l0-types:loss-in-db-or-null
+          |     |       l0-types:power-loss-or-null
           |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types:decimal-2-digits-or-null
+          |     |       l0-types:decimal-2-or-null
           |     +--ro roadm-maxloss?
-          |     |       l0-types:loss-in-db-or-null
+          |     |       l0-types:power-loss-or-null
           |     +--ro roadm-pmax?
-          |     |       l0-types:power-in-dbm-or-null
+          |     |       l0-types:power-dbm-or-null
           |     +--ro roadm-osnr?               l0-types:snr-or-null
           |     +--ro roadm-noise-figure?
-          |             l0-types:decimal-5-digits-or-null
+          |             l0-types:decimal-5-or-null
           +--:(roadm-drop-path)
              +--ro roadm-drop-path* []
                 +--ro frequency-range
@@ -301,26 +296,26 @@ module: ietf-optical-impairment-topology
                 |  +--ro upper-frequency    frequency-thz
                 +--ro roadm-pmd?                union
                 +--ro roadm-cd?
-                |       l0-types:decimal-5-digits-or-null
+                |       l0-types:decimal-5-or-null
                 +--ro roadm-pdl?
-                |       l0-types:loss-in-db-or-null
+                |       l0-types:power-loss-or-null
                 +--ro roadm-inband-crosstalk?
-                |       l0-types:decimal-2-digits-or-null
+                |       l0-types:decimal-2-or-null
                 +--ro roadm-maxloss?
-                |       l0-types:loss-in-db-or-null
+                |       l0-types:power-loss-or-null
                 +--ro roadm-minloss?
-                |       l0-types:loss-in-db-or-null
+                |       l0-types:power-loss-or-null
                 +--ro roadm-typloss?
-                |       l0-types:loss-in-db-or-null
+                |       l0-types:power-loss-or-null
                 +--ro roadm-pmin?
-                |       l0-types:power-in-dbm-or-null
+                |       l0-types:power-dbm-or-null
                 +--ro roadm-pmax?
-                |       l0-types:power-in-dbm-or-null
+                |       l0-types:power-dbm-or-null
                 +--ro roadm-ptyp?
-                |       l0-types:power-in-dbm-or-null
+                |       l0-types:power-dbm-or-null
                 +--ro roadm-osnr?               l0-types:snr-or-null
                 +--ro roadm-noise-figure?
-                        l0-types:decimal-5-digits-or-null
+                        l0-types:decimal-5-or-null
   augment /nw:networks/nw:network/nw:node/tet:te
             /tet:information-source-entry/tet:connectivity-matrices:
     +--ro roadm-path-impairments?   leafref
@@ -374,4 +369,3 @@ module: ietf-optical-impairment-topology
        |       -> ../../../../../../nt:termination-point/tp-id
        +--ro add-path-impairments?    leafref
        +--ro drop-path-impairments?   leafref
-

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -197,19 +197,22 @@ module ietf-optical-impairment-topology {
               "The optical power after the out-voa of each amplifier
               element.";
             choice power-param {
+              mandatory true;
               description
                 "Select the mode: channel power or power spectral
                 density (PSD).";
               case channel-power {
                 leaf nominal-carrier-power {
                   type l0-types:power-in-dbm-or-null;
+                  mandatory true;
                   description
                     "Reference channel power.";
                 }
               }
               case power-spectral-density {
-                leaf nominal-power-spectral-density {
+                leaf nominal-psd {
                   type l0-types:power-spectral-density-or-null;
+                  mandatory true;
                   description
                     "Reference power spectral density (PSD).";
                 }
@@ -634,7 +637,7 @@ module ietf-optical-impairment-topology {
         description
           "Reference channel power.";
       }
-      leaf nominal-power-spectral-density {
+      leaf nominal-psd {
         when "../../equalization-mode='power-spectral-density'";
         type l0-types:power-spectral-density-or-null;
         description

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -108,22 +108,6 @@ module ietf-optical-impairment-topology {
       Linear protection";
   }
 
-  // groupings
-
-  grouping sliceable-transponder-attributes {
-    description
-      "Configuration of a sliceable transponder.";
-    list sliceable-transponder-list {
-      key "carrier-id";
-      config false;
-      description "List of carriers";
-      leaf carrier-id {
-        type uint32;
-        description "Identifier of the carrier";
-      }
-    }
-  }
-
   /*
    * Groupings
    */
@@ -208,7 +192,30 @@ module ietf-optical-impairment-topology {
               value, with respect to loss/gain information on
               elements.";
           }
-          uses power-param;
+          container power-param {
+            description
+              "The optical power after the out-voa of each amplifier
+              element.";
+            choice power-param {
+              description
+                "Select the mode: channel power or power spectral
+                density (PSD).";
+              case channel-power {
+                leaf nominal-carrier-power {
+                  type l0-types:power-in-dbm-or-null;
+                  description
+                    "Reference channel power.";
+                }
+              }
+              case power-spectral-density {
+                leaf nominal-power-spectral-density {
+                  type l0-types:power-spectral-density-or-null;
+                  description
+                    "Reference power spectral density (PSD).";
+                }
+              }
+            }
+          }   // container power-param
           leaf raman-direction {
             type enumeration {
               enum co-propagating {
@@ -263,7 +270,7 @@ module ietf-optical-impairment-topology {
                 uses l0-types:flexi-grid-frequency-slot;
 
                 leaf delta-power {
-                  type l0-types:gain-in-db-or-null;
+                  type l0-types:ratio-in-db-or-null;
                   description
                     " Deviation from the reference carrier power 
                     defined for the OMS.";
@@ -598,40 +605,6 @@ module ietf-optical-impairment-topology {
     }
   }
 
-  grouping power-param {
-    description
-      "optical power or PSD after the ROADM or after the out-voa";
-    choice power-param {
-      description
-        "select the mode: channel power or power spectral density";
-      case channel-power {
-        when "/nw:networks/nw:network/nt:link/tet:te
-            /tet:te-link-attributes/OMS-attributes
-            /equalization-mode='carrier-power'";
-        leaf nominal-carrier-power{
-          type l0-types:power-in-dbm-or-null;
-          description
-            " Reference channel power. Same grouping is used for the
-            OMS power after the ROADM (input of the OMS) or after the
-            out-voa of each amplifier. ";
-        }
-      }
-      case power-spectral-density{
-        when "/nw:networks/nw:network/nt:link/tet:te
-            /tet:te-link-attributes/OMS-attributes
-            /equalization-mode='power-spectral-density'";
-        leaf nominal-power-spectral-density{
-          type l0-types:decimal-16-digits-or-null;
-          units W/Hz ;
-          description
-            " Reference power spectral density after 
-              the ROADM or after the out-voa.
-              Typical value : 3.9 E-14, resolution 0.1nW/MHz";
-        }
-      }
-    }
-  }
-
   grouping oms-general-optical-params {
     description "OMS link optical parameters";
     leaf generalized-snr {
@@ -651,8 +624,24 @@ module ietf-optical-impairment-topology {
         Reporting this value is needed to support optical 
         impairments applications.";
     }
-    uses power-param;
-  }
+    container power-param {
+      description
+        "Optical channel power or power spectral densitity (PSD)
+        after the ROADM.";
+      leaf nominal-carrier-power {
+        when "../../equalization-mode='carrier-power'";
+        type l0-types:power-in-dbm-or-null;
+        description
+          "Reference channel power.";
+      }
+      leaf nominal-power-spectral-density {
+        when "../../equalization-mode='power-spectral-density'";
+        type l0-types:power-spectral-density-or-null;
+        description
+          " Reference power spectral density (PSD).";
+      }
+    }   // container power-param
+  } // grouping oms-general-optical-params
 
   grouping otsi-group {
     description "OTSiG definition , representing client
@@ -760,7 +749,7 @@ module ietf-optical-impairment-topology {
             }
           }
           leaf delta-power {
-            type l0-types:gain-in-db-or-null;
+            type l0-types:ratio-in-db-or-null;
             description
               " Deviation from the reference carrier power defined 
               for the OMS.";
@@ -1124,12 +1113,11 @@ module ietf-optical-impairment-topology {
     when "../../../nw:network-types/tet:te-topology/"
        + "oit:optical-impairment-topology" {
       description
-        "This augment is only valid for Impairment with
-         non-sliceable transponder model";
+        "This augment is only valid for Optical Impairment 
+        topology.";
     }
     description
-      "Tunnel termination point augmentation for non-sliceable
-       transponder model.";
+      "Tunnel termination point augmentation for impairment data.";
 
     list ttp-transceiver {
       when "../../../transponders" {
@@ -1161,20 +1149,6 @@ module ietf-optical-impairment-topology {
       }
     } // list of transceivers
   } // end of augment
-
-  augment "/nw:networks/nw:network/nw:node/tet:te"
-        + "/tet:tunnel-termination-point" {
-    when "../../../nw:network-types/tet:te-topology/"
-       + "oit:optical-impairment-topology" {
-      description
-        "This augment is only valid for optical impairment
-       with sliceable transponder model";
-    }
-    description
-      "Tunnel termination point augmentation for sliceable
-      transponder model.";
-    uses sliceable-transponder-attributes;
-  }
 
   // Should this leaf be moved to te-topology?
   augment "/nw:networks/nw:network/nw:node/nt:termination-point" {

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -87,7 +87,7 @@ module ietf-optical-impairment-topology {
 // this note
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2023-10-19 {
+  revision 2023-12-01 {
     description
       "Initial Version";
     reference
@@ -150,14 +150,14 @@ module ietf-optical-impairment-topology {
             uses l0-types:frequency-range;
           }
           leaf actual-gain {
-            type l0-types:gain-in-db-or-null;
+            type l0-types:power-gain-or-null;
             mandatory true ;
             description
               "The value of the gain provided by the amplification 
               stage of the optical amplifier.";
           }
           leaf tilt-target {
-            type l0-types:decimal-2-digits-or-null;
+            type l0-types:decimal-2-or-null;
             units "dB";
             mandatory true ;
             description
@@ -165,7 +165,7 @@ module ietf-optical-impairment-topology {
               frequency of the amplifier frequency range.";
           }
           leaf out-voa {
-            type l0-types:loss-in-db-or-null;
+            type l0-types:power-loss-or-null;
             mandatory true;
             description
               "Loss introduced by the Variable Optical Attenuator 
@@ -173,7 +173,7 @@ module ietf-optical-impairment-topology {
               the amplifier, if present.";
           }
           leaf in-voa {
-            type l0-types:loss-in-db-or-null;
+            type l0-types:power-loss-or-null;
             mandatory true;
             description
               "Loss introduced by the Variable Optical Attenuator 
@@ -181,7 +181,7 @@ module ietf-optical-impairment-topology {
               amplifier, if present";
           }
           leaf total-output-power {
-            type l0-types:power-in-dbm-or-null;
+            type l0-types:power-dbm-or-null;
             mandatory true;
             description
               "It represent total output power measured in the range
@@ -203,7 +203,7 @@ module ietf-optical-impairment-topology {
                 density (PSD).";
               case channel-power {
                 leaf nominal-carrier-power {
-                  type l0-types:power-in-dbm-or-null;
+                  type l0-types:power-dbm-or-null;
                   mandatory true;
                   description
                     "Reference channel power.";
@@ -211,7 +211,7 @@ module ietf-optical-impairment-topology {
               }
               case power-spectral-density {
                 leaf nominal-psd {
-                  type l0-types:power-spectral-density-or-null;
+                  type l0-types:psd-or-null;
                   mandatory true;
                   description
                     "Reference power spectral density (PSD).";
@@ -246,7 +246,7 @@ module ietf-optical-impairment-topology {
                 "The raman pump central frequency.";
             }
             leaf power {
-              type l0-types:decimal-2-digits-or-null;
+              type l0-types:decimal-2-or-null;
               units "Watts";
               description
                 "The total pump power considering a depolarized pump
@@ -254,7 +254,7 @@ module ietf-optical-impairment-topology {
             }
           }
           leaf pdl {
-            type l0-types:loss-in-db-or-null;
+            type l0-types:power-loss-or-null;
             description "Polarization Dependent Loss (PDL)";
           }
           container media-channel-groups {
@@ -273,7 +273,7 @@ module ietf-optical-impairment-topology {
                 uses l0-types:flexi-grid-frequency-slot;
 
                 leaf delta-power {
-                  type l0-types:ratio-in-db-or-null;
+                  type l0-types:power-ratio-or-null;
                   description
                     " Deviation from the reference carrier power 
                     defined for the OMS.";
@@ -298,35 +298,35 @@ module ietf-optical-impairment-topology {
         description "fiber type";
       }
       leaf length {
-        type l0-types:decimal-2-digits-or-null;
+        type l0-types:decimal-2-or-null;
         units km;
         mandatory true ;
         description "length of fiber";
       }
       leaf loss-coef {
-        type l0-types:decimal-2-digits-or-null;
+        type l0-types:decimal-2-or-null;
         units dB/km;
         mandatory true ;
         description "loss coefficient of the fiber";
       }
       leaf total-loss {
-        type l0-types:loss-in-db-or-null;
+        type l0-types:power-loss-or-null;
         mandatory true ;
         description
           "includes all losses: fiber loss and conn-in and 
            conn-out losses";
       }
       leaf pmd {
-        type l0-types:decimal-2-digits-or-null;
+        type l0-types:decimal-2-or-null;
         units "ps";
         description "pmd of the fiber";
       }
       leaf conn-in{
-        type l0-types:loss-in-db-or-null;
+        type l0-types:power-loss-or-null;
         description "connector-in";
       }
       leaf conn-out{
-        type l0-types:loss-in-db-or-null;
+        type l0-types:power-loss-or-null;
         description "connector-out";
       }
     }
@@ -350,16 +350,16 @@ module ietf-optical-impairment-topology {
         empty value when unknown.";
     }
     leaf roadm-cd {
-      type l0-types:decimal-5-digits-or-null;
+      type l0-types:decimal-5-or-null;
       units "ps/nm";
       description "Chromatic Dispersion (CD)";
     }            
     leaf roadm-pdl {
-      type l0-types:loss-in-db-or-null;
+      type l0-types:power-loss-or-null;
       description "Polarization Dependent Loss (PDL)";
     }
     leaf roadm-inband-crosstalk {
-      type l0-types:decimal-2-digits-or-null;
+      type l0-types:decimal-2-or-null;
       units "dB";
       description
         "In-band crosstalk, or coherent crosstalk, can occur in 
@@ -368,7 +368,7 @@ module ietf-optical-impairment-topology {
         or all but one blocked";
     }
     leaf roadm-maxloss {
-      type l0-types:loss-in-db-or-null;
+      type l0-types:power-loss-or-null;
       description
         "This is the maximum expected path loss from the 
         ROADM ingress to the ROADM egress 
@@ -414,7 +414,7 @@ module ietf-optical-impairment-topology {
       }
     }
     leaf roadm-pmax {
-      type l0-types:power-in-dbm-or-null;
+      type l0-types:power-dbm-or-null;
       description 
         "This is the maximum (per carrier) power level 
         permitted at the add block input ports,
@@ -439,7 +439,7 @@ module ietf-optical-impairment-topology {
         (if both are defined).";
     }
     leaf roadm-noise-figure {
-      type l0-types:decimal-5-digits-or-null;
+      type l0-types:decimal-5-or-null;
       units "dB"; 
       description 
         "Noise Figure. If the add path contains an amplifier, 
@@ -484,7 +484,7 @@ module ietf-optical-impairment-topology {
       }
     }
     leaf roadm-minloss {
-      type l0-types:loss-in-db-or-null;
+      type l0-types:power-loss-or-null;
       description 
         "The net loss from the ROADM input, to the 
         output of the drop block.
@@ -497,7 +497,7 @@ module ietf-optical-impairment-topology {
         including amplifier gain ripple or uncertainty.";
     }
     leaf roadm-typloss {
-      type l0-types:loss-in-db-or-null;
+      type l0-types:power-loss-or-null;
       description 
         "The net loss from the ROADM input, 
         to the output of the drop block.
@@ -512,7 +512,7 @@ module ietf-optical-impairment-topology {
         expected loss.";
     }
     leaf roadm-pmin {
-      type l0-types:power-in-dbm-or-null;
+      type l0-types:power-dbm-or-null;
       description 
         "If the drop path has additional loss
         that is added, for example,
@@ -530,7 +530,7 @@ module ietf-optical-impairment-topology {
         detailed in section xxx of the document yyy."; 
     }
     leaf roadm-pmax {
-      type l0-types:power-in-dbm-or-null;
+      type l0-types:power-dbm-or-null;
       description 
         "If the drop path has additional loss that is added, 
         for example, to hit target power levels into a 
@@ -546,7 +546,7 @@ module ietf-optical-impairment-topology {
         is detailed in section xxx of the document yyy";        
     }
     leaf roadm-ptyp {
-      type l0-types:power-in-dbm-or-null;
+      type l0-types:power-dbm-or-null;
       description 
         "If the drop path has additional loss that is added,
         for example, to hit target power levels into a 
@@ -576,7 +576,7 @@ module ietf-optical-impairment-topology {
         the minimum value between these two should be used";
     }
     leaf roadm-noise-figure {
-      type l0-types:decimal-5-digits-or-null;
+      type l0-types:decimal-5-or-null;
       units "dB"; 
       description 
         "Drop path Noise Figure. 
@@ -600,7 +600,7 @@ module ietf-optical-impairment-topology {
     container concentratedloss{
       description "concentrated loss";
       leaf loss {
-        type l0-types:loss-in-db-or-null;
+        type l0-types:power-loss-or-null;
         mandatory true;
         description
           "Loss introduced by the concentrated loss element.";
@@ -633,13 +633,13 @@ module ietf-optical-impairment-topology {
         after the ROADM.";
       leaf nominal-carrier-power {
         when "../../equalization-mode='carrier-power'";
-        type l0-types:power-in-dbm-or-null;
+        type l0-types:power-dbm-or-null;
         description
           "Reference channel power.";
       }
       leaf nominal-psd {
         when "../../equalization-mode='power-spectral-density'";
-        type l0-types:power-spectral-density-or-null;
+        type l0-types:psd-or-null;
         description
           " Reference power spectral density (PSD).";
       }
@@ -752,7 +752,7 @@ module ietf-optical-impairment-topology {
             }
           }
           leaf delta-power {
-            type l0-types:ratio-in-db-or-null;
+            type l0-types:power-ratio-or-null;
             description
               " Deviation from the reference carrier power defined 
               for the OMS.";

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -70,7 +70,7 @@ module ietf-optical-impairment-topology {
     "This module contains a collection of YANG definitions for
      impairment-aware optical networks.
 
-     Copyright (c) 2023 IETF Trust and the persons identified as
+     Copyright (c) 2024 IETF Trust and the persons identified as
      authors of the code.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or
@@ -87,7 +87,7 @@ module ietf-optical-impairment-topology {
 // this note
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2023-12-01 {
+  revision 2024-01-23 {
     description
       "Initial Version";
     reference
@@ -137,6 +137,17 @@ module ietf-optical-impairment-topology {
               the vendor's specification associated with the
               type-variety.";
           }
+          leaf type-variety {
+            type string;
+            description
+              "String identifier of amplifier element type
+              referencing a specification in a separate equipment
+              catalog.
+              
+              This attributes applies only when the type-variety of
+              the amplifier is not sufficient to describe the
+              amplifier element type.";
+          }
           leaf is-dynamic-gain-equalyzer {
             type boolean;
             description
@@ -149,48 +160,12 @@ module ietf-optical-impairment-topology {
               element.";
             uses l0-types:frequency-range;
           }
-          leaf actual-gain {
-            type l0-types:power-gain-or-null;
-            mandatory true ;
+          leaf stage-order {
+            type uint8;
+            default 1;
             description
-              "The value of the gain provided by the amplification 
-              stage of the optical amplifier.";
-          }
-          leaf tilt-target {
-            type l0-types:decimal-2-or-null;
-            units "dB";
-            mandatory true ;
-            description
-              "The tilt target defined between lower and upper
-              frequency of the amplifier frequency range.";
-          }
-          leaf out-voa {
-            type l0-types:power-loss-or-null;
-            mandatory true;
-            description
-              "Loss introduced by the Variable Optical Attenuator 
-              (VOA) at the output of the amplification stage of 
-              the amplifier, if present.";
-          }
-          leaf in-voa {
-            type l0-types:power-loss-or-null;
-            mandatory true;
-            description
-              "Loss introduced by the Variable Optical Attenuator 
-              (VOA) at the input of the amplification stage of the 
-              amplifier, if present";
-          }
-          leaf total-output-power {
-            type l0-types:power-dbm-or-null;
-            mandatory true;
-            description
-              "It represent total output power measured in the range
-              specified by the frequency-range.
-              
-              Optical power is especially needed to re-compute/check
-              consistency of span (fiber+ concentrated loss) loss
-              value, with respect to loss/gain information on
-              elements.";
+              "It allows defining for each spectrum badwidth the
+              cascade order of each amplifier-element.";
           }
           container power-param {
             description
@@ -219,68 +194,131 @@ module ietf-optical-impairment-topology {
               }
             }
           }   // container power-param
-          leaf raman-direction {
-            type enumeration {
-              enum co-propagating {
-                description
-                  "Co-propagating indicates that optical pump light
-                  is injected in the same direction to the optical
-                  signal that is amplified (forward pump).";
-              }
-              enum counter-propagating {
-                description
-                  "Counter-propagating indicates that optical pump
-                  light is injected in opposite direction to the
-                  optical signal that is amplified (backward pump).";
-              }
-            }
-            description
-              "The direction of injection of the raman pump.";
-          }
-          list raman-pump {
-            description
-              "The list of pumps for the Raman amplifier.";
-            leaf frequency {
-              type l0-types:frequency-thz;
-              description
-                "The raman pump central frequency.";
-            }
-            leaf power {
-              type l0-types:decimal-2-or-null;
-              units "Watts";
-              description
-                "The total pump power considering a depolarized pump
-                at the raman pump central frequency.";
-            }
-          }
           leaf pdl {
             type l0-types:power-loss-or-null;
             description "Polarization Dependent Loss (PDL)";
           }
-          container media-channel-groups {
+          choice amplifier-element-type {
+            mandatory true;
             description
-              "The top level container for the list of media channel 
-              groups.";
-            list media-channel-group {
+              "Identifies whether the amplifier element is an
+              Optical Amplifier (OA) or a Dynamic Gain Equalyzer
+              (DGE).";
+            container optical-amplifier {
               description
-                "The list of media channel groups";
-              list media-channels {
-                // key "flexi-n";
+                "The attributes applicable only to amplifier
+                elements";
+              leaf actual-gain {
+                type l0-types:power-gain-or-null;
+                mandatory true;
                 description
-                  "List of media channels represented as (n,m)";
-
-                // this grouping add both n.m values
-                uses l0-types:flexi-grid-frequency-slot;
-
-                leaf delta-power {
-                  type l0-types:power-ratio-or-null;
-                  description
-                    " Deviation from the reference carrier power 
-                    defined for the OMS.";
+                  "The value of the gain provided by the
+                  amplification  stage of the optical amplifier.";
+              }
+              leaf in-voa {
+                type l0-types:power-loss-or-null;
+                description
+                  "Loss introduced by the Variable Optical Attenuator
+                  (VOA) at the input of the amplification stage of
+                  the amplifier, if present";
+              }
+              leaf out-voa {
+                type l0-types:power-loss-or-null;
+                description
+                  "Loss introduced by the Variable Optical Attenuator
+                  (VOA) at the output of the amplification stage of
+                  the amplifier, if present.";
+              }
+              leaf tilt-target {
+                type l0-types:decimal-2-or-null;
+                units "dB";
+                mandatory true ;
+                description
+                  "The tilt target defined between lower and upper
+                  frequency of the amplifier frequency range.";
+              }
+              leaf total-output-power {
+                type l0-types:power-dbm-or-null;
+                mandatory true;
+                description
+                  "It represent total output power measured in the
+                  range specified by the frequency-range.
+                  
+                  Optical power is especially needed to
+                  re-compute/check consistency of span
+                  (fiber + concentrated loss) loss value, with
+                  respect to loss/gain information on elements.";
+              }
+              leaf raman-direction {
+                type enumeration {
+                  enum co-propagating {
+                    description
+                      "Co-propagating indicates that optical pump
+                      light is injected in the same direction to the
+                      optical signal that is amplified
+                      (forward pump).";
+                  }
+                  enum counter-propagating {
+                    description
+                      "Counter-propagating indicates that optical
+                      pump light is injected in opposite direction
+                      to the optical signal that is amplified
+                      (backward pump).";
+                  }
                 }
-              } // media channels list
-            } // media-channel-groups list
-          }
+                description
+                  "The direction of injection of the raman pump.";
+              }
+              list raman-pump {
+                description
+                  "The list of pumps for the Raman amplifier.";
+                leaf frequency {
+                  type l0-types:frequency-thz;
+                  description
+                    "The raman pump central frequency.";
+                }
+                leaf power {
+                  type l0-types:decimal-2-or-null;
+                  units "Watts";
+                  description
+                    "The total pump power considering a depolarized
+                    pump at the raman pump central frequency.";
+                }
+              }
+            }   // container optical-amplifier
+            container dynamic-gain-equalyzer {
+              presence
+                "When present it indicates that the amplifier element
+                is a Dynamic Gain Equalyzer (DGE)";
+              description
+                "The attributes applicable only to DEG amplifier
+                elements.";
+              container media-channel-groups {
+                description
+                  "The top level container for the list of media
+                  channel groups.";
+                list media-channel-group {
+                  description
+                    "The list of media channel groups";
+                  list media-channels {
+                    // key "flexi-n";
+                    description
+                      "List of media channels represented as (n,m)";
+
+                    // this grouping add both n.m values
+                    uses l0-types:flexi-grid-frequency-slot;
+
+                    leaf delta-power {
+                      type l0-types:power-ratio-or-null;
+                      description
+                        " Deviation from the reference carrier power 
+                        defined for the OMS.";
+                    }
+                  } // media channels list
+                } // media-channel-groups list
+              }   // container media-channel-groups
+            }   // container dynamic-gain-equalyzer
+          } // choice amplifier-element-type
         }  // list amplifier-element
       }  // container operational
     }  // container amplifier


### PR DESCRIPTION
- Removed grouping power-param and copied attributes when used: fix #155
- Updated data type for delta-power attribute: fix #158
- Removed grouping sliceable-transponder-attributes: fix #159
- Shortened powtypes and attribute names: fix #134 
  - power-spectral-density -> psd
  - power-spectral-density-or-null -> psd-or-null
  - power-in-dbm -> power-dbm
  - power-in-dbm-or-null -> power-dbm-or-null
  - decimal-2-digits -> decimal-2
  - decimal-2-digits-or-null -> decimal-2-or-null
  - decimal-5-digits -> decimal-5
  - decimal-5-digits-or-null -> decimal-5-or-null
  - ratio-in-db -> power-ratio
  - ratio-in-db-or-null -> power-ratio-or-null
  - gain-in-db -> power-gain
  - gain-in-db-or-null -> power-gain-or-null
  - loss-in-db -> power-loss
  - loss-in-db-or-null -> power-loss-or-null

- Added YANG model for DGE: see #153
  - added new stage-order attribute to amplifier-element
  - added new type-variety attribute to amplifier-element 
  - added amplifier-element-type choice ot amplifier-element
  - moved actual-gain, in-voa, out-voa, tilt-target, total-output-power, raman-direction and raman-pump under the optical-amplifier container
  - marked in-voa and out-voa as optional
  - moved media-channel-groups under the dynamic-gain-equalyzer container

---

- [x] Pending merge of https://github.com/ietf-ccamp-wg/ietf-ccamp-layer0-types-ext-RFC9093-bis/pull/82

---

Co-authored-by: sergio belotti <sergio.belotti@nokia.com>