### PR TITLE
Further updates for WG LC preparation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .project
 *.sh
+*.bash

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -12,73 +12,110 @@ module: ietf-optical-impairment-topology
     |        +--ro otsi-carrier-id           uint16
     |        +--ro otsi-carrier-frequency?   union
     |        +--ro e2e-mc-path-id*           uint16
-    +--rw templates
-       +--rw roadm-path-impairments
-          +--ro roadm-path-impairment* [roadm-path-impairments-id]
-             +--ro roadm-path-impairments-id    string
-             +--ro (impairment-type)?
-                +--:(roadm-express-path)
-                |  +--ro roadm-express-path* []
-                |     +--ro frequency-range
-                |     |  +--ro lower-frequency    frequency-thz
-                |     |  +--ro upper-frequency    frequency-thz
-                |     +--ro roadm-pmd?                union
-                |     +--ro roadm-cd?                 l0-types:decim\
+    +--ro templates
+       +--ro roadm-path-impairments
+       |  +--ro roadm-path-impairment* [roadm-path-impairments-id]
+       |     +--ro roadm-path-impairments-id    string
+       |     +--ro (impairment-type)?
+       |        +--:(roadm-express-path)
+       |        |  +--ro roadm-express-path* []
+       |        |     +--ro frequency-range
+       |        |     |  +--ro lower-frequency    frequency-thz
+       |        |     |  +--ro upper-frequency    frequency-thz
+       |        |     +--ro roadm-pmd?                union
+       |        |     +--ro roadm-cd?                 l0-types:decim\
 \al-5-or-null
-                |     +--ro roadm-pdl?                l0-types:power\
+       |        |     +--ro roadm-pdl?                l0-types:power\
 \-loss-or-null
-                |     +--ro roadm-inband-crosstalk?   l0-types:decim\
+       |        |     +--ro roadm-inband-crosstalk?   l0-types:decim\
 \al-2-or-null
-                |     +--ro roadm-maxloss?            l0-types:power\
+       |        |     +--ro roadm-maxloss?            l0-types:power\
 \-loss-or-null
-                +--:(roadm-add-path)
-                |  +--ro roadm-add-path* []
-                |     +--ro frequency-range
-                |     |  +--ro lower-frequency    frequency-thz
-                |     |  +--ro upper-frequency    frequency-thz
-                |     +--ro roadm-pmd?                union
-                |     +--ro roadm-cd?                 l0-types:decim\
+       |        +--:(roadm-add-path)
+       |        |  +--ro roadm-add-path* []
+       |        |     +--ro frequency-range
+       |        |     |  +--ro lower-frequency    frequency-thz
+       |        |     |  +--ro upper-frequency    frequency-thz
+       |        |     +--ro roadm-pmd?                union
+       |        |     +--ro roadm-cd?                 l0-types:decim\
 \al-5-or-null
-                |     +--ro roadm-pdl?                l0-types:power\
+       |        |     +--ro roadm-pdl?                l0-types:power\
 \-loss-or-null
-                |     +--ro roadm-inband-crosstalk?   l0-types:decim\
+       |        |     +--ro roadm-inband-crosstalk?   l0-types:decim\
 \al-2-or-null
-                |     +--ro roadm-maxloss?            l0-types:power\
+       |        |     +--ro roadm-maxloss?            l0-types:power\
 \-loss-or-null
-                |     +--ro roadm-pmax?               l0-types:power\
+       |        |     +--ro roadm-pmax?               l0-types:power\
 \-dbm-or-null
-                |     +--ro roadm-osnr?               l0-types:snr-o\
+       |        |     +--ro roadm-osnr?               l0-types:snr-o\
 \r-null
-                |     +--ro roadm-noise-figure?       l0-types:decim\
+       |        |     +--ro roadm-noise-figure?       l0-types:decim\
 \al-5-or-null
-                +--:(roadm-drop-path)
-                   +--ro roadm-drop-path* []
-                      +--ro frequency-range
-                      |  +--ro lower-frequency    frequency-thz
-                      |  +--ro upper-frequency    frequency-thz
-                      +--ro roadm-pmd?                union
-                      +--ro roadm-cd?                 l0-types:decim\
+       |        +--:(roadm-drop-path)
+       |           +--ro roadm-drop-path* []
+       |              +--ro frequency-range
+       |              |  +--ro lower-frequency    frequency-thz
+       |              |  +--ro upper-frequency    frequency-thz
+       |              +--ro roadm-pmd?                union
+       |              +--ro roadm-cd?                 l0-types:decim\
 \al-5-or-null
-                      +--ro roadm-pdl?                l0-types:power\
+       |              +--ro roadm-pdl?                l0-types:power\
 \-loss-or-null
-                      +--ro roadm-inband-crosstalk?   l0-types:decim\
+       |              +--ro roadm-inband-crosstalk?   l0-types:decim\
 \al-2-or-null
-                      +--ro roadm-maxloss?            l0-types:power\
+       |              +--ro roadm-maxloss?            l0-types:power\
 \-loss-or-null
-                      +--ro roadm-minloss?            l0-types:power\
+       |              +--ro roadm-minloss?            l0-types:power\
 \-loss-or-null
-                      +--ro roadm-typloss?            l0-types:power\
+       |              +--ro roadm-typloss?            l0-types:power\
 \-loss-or-null
-                      +--ro roadm-pmin?               l0-types:power\
+       |              +--ro roadm-pmin?               l0-types:power\
 \-dbm-or-null
-                      +--ro roadm-pmax?               l0-types:power\
+       |              +--ro roadm-pmax?               l0-types:power\
 \-dbm-or-null
-                      +--ro roadm-ptyp?               l0-types:power\
+       |              +--ro roadm-ptyp?               l0-types:power\
 \-dbm-or-null
-                      +--ro roadm-osnr?               l0-types:snr-o\
+       |              +--ro roadm-osnr?               l0-types:snr-o\
 \r-null
-                      +--ro roadm-noise-figure?       l0-types:decim\
+       |              +--ro roadm-noise-figure?       l0-types:decim\
 \al-5-or-null
+       +--ro explicit-transceiver-modes
+          +--ro explicit-transceiver-mode* [explicit-transceiver-mod\
+\e-id]
+             +--ro explicit-transceiver-mode-id        string
+             +--ro line-coding-bitrate?                identityref
+             +--ro bitrate?                            uint16
+             +--ro max-diff-group-delay?               uint32
+             +--ro max-chromatic-dispersion?           decimal64
+             +--ro cd-penalty* []
+             |  +--ro cd-value         union
+             |  +--ro penalty-value    union
+             +--ro max-polarization-mode-dispersion?   decimal64
+             +--ro pmd-penalty* []
+             |  +--ro pmd-value        union
+             |  +--ro penalty-value    union
+             +--ro max-polarization-dependant-loss     power-loss-or\
+\-null
+             +--ro pdl-penalty* []
+             |  +--ro pdl-value        power-loss-or-null
+             |  +--ro penalty-value    union
+             +--ro available-modulation-type?          identityref
+             +--ro min-OSNR?                           snr
+             +--ro rx-ref-channel-power?               power-dbm
+             +--ro rx-channel-power-penalty* []
+             |  +--ro rx-channel-power-value    power-dbm-or-null
+             |  +--ro penalty-value             union
+             +--ro min-Q-factor?                       int32
+             +--ro available-baud-rate?                uint32
+             +--ro roll-off?                           decimal64
+             +--ro min-carrier-spacing?                frequency-ghz
+             +--ro available-fec-type?                 identityref
+             +--ro fec-code-rate?                      decimal64
+             +--ro fec-threshold?                      decimal64
+             +--ro in-band-osnr?                       snr
+             +--ro out-of-band-osnr?                   snr
+             +--ro tx-polarization-power-difference?   power-ratio
+             +--ro polarization-skew?                  decimal64
   augment /nw:networks/nw:network/nw:node:
     +--rw transponders!
     |  +--ro transponder* [transponder-id]
@@ -132,81 +169,30 @@ module: ietf-optical-impairment-topology
 \bm
     |        |        +--:(explicit-mode)
     |        |           +--ro explicit-mode
-    |        |              +--ro line-coding-bitrate?              \
-\  identityref
-    |        |              +--ro bitrate?                          \
-\  uint16
-    |        |              +--ro max-diff-group-delay?             \
-\  uint32
-    |        |              +--ro max-chromatic-dispersion?         \
-\  decimal64
-    |        |              +--ro cd-penalty* []
-    |        |              |  +--ro cd-value         union
-    |        |              |  +--ro penalty-value    union
-    |        |              +--ro max-polarization-mode-dispersion? \
-\  decimal64
-    |        |              +--ro pmd-penalty* []
-    |        |              |  +--ro pmd-value        union
-    |        |              |  +--ro penalty-value    union
-    |        |              +--ro max-polarization-dependant-loss   \
-\  power-loss-or-null
-    |        |              +--ro pdl-penalty* []
-    |        |              |  +--ro pdl-value        power-loss-or-\
-\null
-    |        |              |  +--ro penalty-value    union
-    |        |              +--ro available-modulation-type?        \
-\  identityref
-    |        |              +--ro min-OSNR?                         \
-\  snr
-    |        |              +--ro rx-ref-channel-power?             \
-\  power-dbm
-    |        |              +--ro rx-channel-power-penalty* []
-    |        |              |  +--ro rx-channel-power-value    power\
-\-dbm-or-null
-    |        |              |  +--ro penalty-value             union
-    |        |              +--ro min-Q-factor?                     \
-\  int32
-    |        |              +--ro available-baud-rate?              \
-\  uint32
-    |        |              +--ro roll-off?                         \
-\  decimal64
-    |        |              +--ro min-carrier-spacing?              \
-\  frequency-ghz
-    |        |              +--ro available-fec-type?               \
-\  identityref
-    |        |              +--ro fec-code-rate?                    \
-\  decimal64
-    |        |              +--ro fec-threshold?                    \
-\  decimal64
-    |        |              +--ro in-band-osnr?                     \
-\  snr
-    |        |              +--ro out-of-band-osnr?                 \
-\  snr
-    |        |              +--ro tx-polarization-power-difference? \
-\  power-ratio
-    |        |              +--ro polarization-skew?                \
-\  decimal64
-    |        |              +--ro min-central-frequency?            \
-\  frequency-thz
-    |        |              +--ro max-central-frequency?            \
-\  frequency-thz
-    |        |              +--ro transceiver-tunability?           \
-\  frequency-ghz
-    |        |              +--ro tx-channel-power-min?             \
-\  power-dbm
-    |        |              +--ro tx-channel-power-max?             \
-\  power-dbm
-    |        |              +--ro rx-channel-power-min?             \
-\  power-dbm
-    |        |              +--ro rx-channel-power-max?             \
-\  power-dbm
-    |        |              +--ro rx-total-power-max?               \
-\  power-dbm
+    |        |              +--ro min-central-frequency?           f\
+\requency-thz
+    |        |              +--ro max-central-frequency?           f\
+\requency-thz
+    |        |              +--ro transceiver-tunability?          f\
+\requency-ghz
+    |        |              +--ro tx-channel-power-min?            p\
+\ower-dbm
+    |        |              +--ro tx-channel-power-max?            p\
+\ower-dbm
+    |        |              +--ro rx-channel-power-min?            p\
+\ower-dbm
+    |        |              +--ro rx-channel-power-max?            p\
+\ower-dbm
+    |        |              +--ro rx-total-power-max?              p\
+\ower-dbm
     |        |              +--ro compatible-modes
-    |        |                 +--ro supported-application-codes*   \
+    |        |              |  +--ro supported-application-codes*   \
 \   -> ../../../mode-id
-    |        |                 +--ro supported-organizational-modes*\
+    |        |              |  +--ro supported-organizational-modes*\
 \   -> ../../../mode-id
+    |        |              +--ro explicit-transceiver-mode-ref?   -\
+\> ../../../../../../../../templates/explicit-transceiver-modes/expl\
+\icit-transceiver-mode/explicit-transceiver-mode-id
     |        +--ro configured-mode?               union
     |        +--ro line-coding-bitrate?           identityref
     |        +--ro tx-channel-power?              power-dbm-or-null

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -1,4 +1,4 @@
-=============== NOTE: '\\' line wrapping per RFC 8792 ===============
+=============== NOTE: '\' line wrapping per RFC 8792 ================
 
 module: ietf-optical-impairment-topology
 
@@ -23,65 +23,65 @@ module: ietf-optical-impairment-topology
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
        |        |     +--ro roadm-pmd?                union
-       |        |     +--ro roadm-cd?                 l0-types:decim\
-\al-5-or-null
-       |        |     +--ro roadm-pdl?                l0-types:power\
-\-loss-or-null
-       |        |     +--ro roadm-inband-crosstalk?   l0-types:decim\
-\al-2-or-null
-       |        |     +--ro roadm-maxloss?            l0-types:power\
-\-loss-or-null
+       |        |     +--ro roadm-cd?
+       |        |     |       l0-types:decimal-5-or-null
+       |        |     +--ro roadm-pdl?
+       |        |     |       l0-types:power-loss-or-null
+       |        |     +--ro roadm-inband-crosstalk?
+       |        |     |       l0-types:decimal-2-or-null
+       |        |     +--ro roadm-maxloss?
+       |        |             l0-types:power-loss-or-null
        |        +--:(roadm-add-path)
        |        |  +--ro roadm-add-path* []
        |        |     +--ro frequency-range
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
        |        |     +--ro roadm-pmd?                union
-       |        |     +--ro roadm-cd?                 l0-types:decim\
-\al-5-or-null
-       |        |     +--ro roadm-pdl?                l0-types:power\
-\-loss-or-null
-       |        |     +--ro roadm-inband-crosstalk?   l0-types:decim\
-\al-2-or-null
-       |        |     +--ro roadm-maxloss?            l0-types:power\
-\-loss-or-null
-       |        |     +--ro roadm-pmax?               l0-types:power\
-\-dbm-or-null
-       |        |     +--ro roadm-osnr?               l0-types:snr-o\
-\r-null
-       |        |     +--ro roadm-noise-figure?       l0-types:decim\
-\al-5-or-null
+       |        |     +--ro roadm-cd?
+       |        |     |       l0-types:decimal-5-or-null
+       |        |     +--ro roadm-pdl?
+       |        |     |       l0-types:power-loss-or-null
+       |        |     +--ro roadm-inband-crosstalk?
+       |        |     |       l0-types:decimal-2-or-null
+       |        |     +--ro roadm-maxloss?
+       |        |     |       l0-types:power-loss-or-null
+       |        |     +--ro roadm-pmax?
+       |        |     |       l0-types:power-dbm-or-null
+       |        |     +--ro roadm-osnr?
+       |        |     |       l0-types:snr-or-null
+       |        |     +--ro roadm-noise-figure?
+       |        |             l0-types:decimal-5-or-null
        |        +--:(roadm-drop-path)
        |           +--ro roadm-drop-path* []
        |              +--ro frequency-range
        |              |  +--ro lower-frequency    frequency-thz
        |              |  +--ro upper-frequency    frequency-thz
        |              +--ro roadm-pmd?                union
-       |              +--ro roadm-cd?                 l0-types:decim\
-\al-5-or-null
-       |              +--ro roadm-pdl?                l0-types:power\
-\-loss-or-null
-       |              +--ro roadm-inband-crosstalk?   l0-types:decim\
-\al-2-or-null
-       |              +--ro roadm-maxloss?            l0-types:power\
-\-loss-or-null
-       |              +--ro roadm-minloss?            l0-types:power\
-\-loss-or-null
-       |              +--ro roadm-typloss?            l0-types:power\
-\-loss-or-null
-       |              +--ro roadm-pmin?               l0-types:power\
-\-dbm-or-null
-       |              +--ro roadm-pmax?               l0-types:power\
-\-dbm-or-null
-       |              +--ro roadm-ptyp?               l0-types:power\
-\-dbm-or-null
-       |              +--ro roadm-osnr?               l0-types:snr-o\
-\r-null
-       |              +--ro roadm-noise-figure?       l0-types:decim\
-\al-5-or-null
+       |              +--ro roadm-cd?
+       |              |       l0-types:decimal-5-or-null
+       |              +--ro roadm-pdl?
+       |              |       l0-types:power-loss-or-null
+       |              +--ro roadm-inband-crosstalk?
+       |              |       l0-types:decimal-2-or-null
+       |              +--ro roadm-maxloss?
+       |              |       l0-types:power-loss-or-null
+       |              +--ro roadm-minloss?
+       |              |       l0-types:power-loss-or-null
+       |              +--ro roadm-typloss?
+       |              |       l0-types:power-loss-or-null
+       |              +--ro roadm-pmin?
+       |              |       l0-types:power-dbm-or-null
+       |              +--ro roadm-pmax?
+       |              |       l0-types:power-dbm-or-null
+       |              +--ro roadm-ptyp?
+       |              |       l0-types:power-dbm-or-null
+       |              +--ro roadm-osnr?
+       |              |       l0-types:snr-or-null
+       |              +--ro roadm-noise-figure?
+       |                      l0-types:decimal-5-or-null
        +--ro explicit-transceiver-modes
-          +--ro explicit-transceiver-mode* [explicit-transceiver-mod\
-\e-id]
+          +--ro explicit-transceiver-mode*
+                  [explicit-transceiver-mode-id]
              +--ro explicit-transceiver-mode-id        string
              +--ro line-coding-bitrate?                identityref
              +--ro bitrate?                            uint16
@@ -94,8 +94,8 @@ module: ietf-optical-impairment-topology
              +--ro pmd-penalty* []
              |  +--ro pmd-value        union
              |  +--ro penalty-value    union
-             +--ro max-polarization-dependant-loss     power-loss-or\
-\-null
+             +--ro max-polarization-dependant-loss
+             |       power-loss-or-null
              +--ro pdl-penalty* []
              |  +--ro pdl-value        power-loss-or-null
              |  +--ro penalty-value    union
@@ -129,15 +129,15 @@ module: ietf-optical-impairment-topology
     |        |     +--ro mode-id                         string
     |        |     +--ro (mode)
     |        |        +--:(G.698.2)
-    |        |        |  +--ro standard-mode?            standard-mo\
-\de
+    |        |        |  +--ro standard-mode?
+    |        |        |  |       standard-mode
     |        |        |  +--ro line-coding-bitrate*      identityref
-    |        |        |  +--ro min-central-frequency?    frequency-t\
-\hz
-    |        |        |  +--ro max-central-frequency?    frequency-t\
-\hz
-    |        |        |  +--ro transceiver-tunability?   frequency-g\
-\hz
+    |        |        |  +--ro min-central-frequency?
+    |        |        |  |       frequency-thz
+    |        |        |  +--ro max-central-frequency?
+    |        |        |  |       frequency-thz
+    |        |        |  +--ro transceiver-tunability?
+    |        |        |  |       frequency-ghz
     |        |        |  +--ro tx-channel-power-min?     power-dbm
     |        |        |  +--ro tx-channel-power-max?     power-dbm
     |        |        |  +--ro rx-channel-power-min?     power-dbm
@@ -145,80 +145,73 @@ module: ietf-optical-impairment-topology
     |        |        |  +--ro rx-total-power-max?       power-dbm
     |        |        +--:(organizational-mode)
     |        |        |  +--ro organizational-mode
-    |        |        |     +--ro operational-mode?          operati\
-\onal-mode
-    |        |        |     +--ro organization-identifier?   organiz\
-\ation-identifier
-    |        |        |     +--ro line-coding-bitrate*       identit\
-\yref
-    |        |        |     +--ro min-central-frequency?     frequen\
-\cy-thz
-    |        |        |     +--ro max-central-frequency?     frequen\
-\cy-thz
-    |        |        |     +--ro transceiver-tunability?    frequen\
-\cy-ghz
-    |        |        |     +--ro tx-channel-power-min?      power-d\
-\bm
-    |        |        |     +--ro tx-channel-power-max?      power-d\
-\bm
-    |        |        |     +--ro rx-channel-power-min?      power-d\
-\bm
-    |        |        |     +--ro rx-channel-power-max?      power-d\
-\bm
-    |        |        |     +--ro rx-total-power-max?        power-d\
-\bm
+    |        |        |     +--ro operational-mode?
+    |        |        |     |       operational-mode
+    |        |        |     +--ro organization-identifier?
+    |        |        |     |       organization-identifier
+    |        |        |     +--ro line-coding-bitrate*
+    |        |        |     |       identityref
+    |        |        |     +--ro min-central-frequency?
+    |        |        |     |       frequency-thz
+    |        |        |     +--ro max-central-frequency?
+    |        |        |     |       frequency-thz
+    |        |        |     +--ro transceiver-tunability?
+    |        |        |     |       frequency-ghz
+    |        |        |     +--ro tx-channel-power-min?
+    |        |        |     |       power-dbm
+    |        |        |     +--ro tx-channel-power-max?
+    |        |        |     |       power-dbm
+    |        |        |     +--ro rx-channel-power-min?
+    |        |        |     |       power-dbm
+    |        |        |     +--ro rx-channel-power-max?
+    |        |        |     |       power-dbm
+    |        |        |     +--ro rx-total-power-max?
+    |        |        |             power-dbm
     |        |        +--:(explicit-mode)
     |        |           +--ro explicit-mode
-    |        |              +--ro min-central-frequency?           f\
-\requency-thz
-    |        |              +--ro max-central-frequency?           f\
-\requency-thz
-    |        |              +--ro transceiver-tunability?          f\
-\requency-ghz
-    |        |              +--ro tx-channel-power-min?            p\
-\ower-dbm
-    |        |              +--ro tx-channel-power-max?            p\
-\ower-dbm
-    |        |              +--ro rx-channel-power-min?            p\
-\ower-dbm
-    |        |              +--ro rx-channel-power-max?            p\
-\ower-dbm
-    |        |              +--ro rx-total-power-max?              p\
-\ower-dbm
+    |        |              +--ro min-central-frequency?
+    |        |              |       frequency-thz
+    |        |              +--ro max-central-frequency?
+    |        |              |       frequency-thz
+    |        |              +--ro transceiver-tunability?
+    |        |              |       frequency-ghz
+    |        |              +--ro tx-channel-power-min?
+    |        |              |       power-dbm
+    |        |              +--ro tx-channel-power-max?
+    |        |              |       power-dbm
+    |        |              +--ro rx-channel-power-min?
+    |        |              |       power-dbm
+    |        |              +--ro rx-channel-power-max?
+    |        |              |       power-dbm
+    |        |              +--ro rx-total-power-max?
+    |        |              |       power-dbm
     |        |              +--ro compatible-modes
-    |        |              |  +--ro supported-application-codes*   \
-\   -> ../../../mode-id
-    |        |              |  +--ro supported-organizational-modes*\
-\   -> ../../../mode-id
-    |        |              +--ro explicit-transceiver-mode-ref?   -\
-\> ../../../../../../../../templates/explicit-transceiver-modes/expl\
-\icit-transceiver-mode/explicit-transceiver-mode-id
+    |        |              |  +--ro supported-application-codes*
+    |        |              |  |       -> ../../../mode-id
+    |        |              |  +--ro supported-organizational-modes*
+    |        |              |          -> ../../../mode-id
+    |        |              +--ro explicit-transceiver-mode-ref?
+    |        |                      leafref
     |        +--ro configured-mode?               union
     |        +--ro line-coding-bitrate?           identityref
     |        +--ro tx-channel-power?              power-dbm-or-null
     |        +--ro rx-channel-power?              power-dbm-or-null
     |        +--ro rx-total-power?                power-dbm-or-null
     |        +--ro outgoing-otsi
-    |        |  +--ro otsi-group-ref?   -> ../../../../../../otsis/o\
-\tsi-group/otsi-group-id
-    |        |  +--ro otsi-ref?         -> ../../../../../../otsis/o\
-\tsi-group[otsi-group-id=current()/../otsi-group-ref]/otsi/otsi-carr\
-\ier-id
+    |        |  +--ro otsi-group-ref?   leafref
+    |        |  +--ro otsi-ref?         leafref
     |        +--ro incoming-otsi
-    |        |  +--ro otsi-group-ref?   -> ../../../../../../otsis/o\
-\tsi-group/otsi-group-id
-    |        |  +--ro otsi-ref?         -> ../../../../../../otsis/o\
-\tsi-group[otsi-group-id=current()/../otsi-group-ref]/otsi/otsi-carr\
-\ier-id
+    |        |  +--ro otsi-group-ref?   leafref
+    |        |  +--ro otsi-ref?         leafref
     |        +--ro configured-termination-type?   enumeration
     +--rw regen-groups!
        +--ro regen-group* [group-id]
           +--ro group-id           uint32
           +--ro regen-metric?      uint32
-          +--ro transponder-ref*   -> ../../../transponders/transpon\
-\der/transponder-id
-  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attribu\
-\tes:
+          +--ro transponder-ref*
+                  -> ../../../transponders/transponder/transponder-id
+  augment /nw:networks/nw:network/nt:link/tet:te
+            /tet:te-link-attributes:
     +--ro OMS-attributes
        +--ro generalized-snr?        l0-types:snr
        +--ro equalization-mode?      identityref
@@ -230,27 +223,19 @@ module: ietf-optical-impairment-topology
        |     +--ro media-channels* []
        |        +--ro flexi-n?          l0-types:flexi-n
        |        +--ro flexi-m?          l0-types:flexi-m
-       |        +--ro otsi-group-ref?   -> ../../../../../../../../o\
-\tsis/otsi-group/otsi-group-id
+       |        +--ro otsi-group-ref?   leafref
        |        +--ro otsi-ref* []
-       |        |  +--ro otsi-carrier-ref?   -> ../../../../../../..\
-\/../../otsis/otsi-group[otsi-group-id=current()/../../otsi-group-re\
-\f]/otsi/otsi-carrier-id
-       |        |  +--ro e2e-mc-path-ref*    -> ../../../../../../..\
-\/../../otsis/otsi-group[otsi-group-id=current()/../../otsi-group-re\
-\f]/otsi[otsi-carrier-id=current()/../otsi-carrier-ref]/e2e-mc-path-\
-\id
+       |        |  +--ro otsi-carrier-ref?   leafref
+       |        |  +--ro e2e-mc-path-ref*    leafref
        |        +--ro delta-power?      l0-types:power-ratio-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
              +--ro oms-element-uid?          union
              +--ro reverse-element-ref
-             |  +--ro link-ref?          -> ../../../../../../../../\
-\nt:link/link-id
-             |  +--ro oms-element-ref*   -> ../../../../../../../../\
-\nt:link[nt:link-id=current()/../link-ref]/tet:te/te-link-attributes\
-\/OMS-attributes/OMS-elements/OMS-element/elt-index
+             |  +--ro link-ref?
+             |  |       -> ../../../../../../../../nt:link/link-id
+             |  +--ro oms-element-ref*   leafref
              +--ro (element)
                 +--:(amplifier)
                 |  +--ro geolocation
@@ -261,155 +246,149 @@ module: ietf-optical-impairment-topology
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element* []
-                |           +--ro name?                           st\
-\ring
-                |           +--ro type-variety?                   st\
-\ring
-                |           +--ro is-dynamic-gain-equalyzer?      bo\
-\olean
+                |           +--ro name?
+                |           |       string
+                |           +--ro type-variety?
+                |           |       string
+                |           +--ro is-dynamic-gain-equalyzer?
+                |           |       boolean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
-                |           +--ro stage-order?                    ui\
-\nt8
+                |           +--ro stage-order?
+                |           |       uint8
                 |           +--ro power-param
                 |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
-                |           |     |  +--ro nominal-carrier-power    \
-\l0-types:power-dbm-or-null
+                |           |     |  +--ro nominal-carrier-power
+                |           |     |          l0-types:power-dbm-or-n\
+ull
                 |           |     +--:(power-spectral-density)
-                |           |        +--ro nominal-psd              \
-\l0-types:psd-or-null
-                |           +--ro pdl?                            l0\
-\-types:power-loss-or-null
+                |           |        +--ro nominal-psd
+                |           |                l0-types:psd-or-null
+                |           +--ro pdl?
+                |           |       l0-types:power-loss-or-null
                 |           +--ro (amplifier-element-type)
                 |              +--:(optical-amplifier)
                 |              |  +--ro optical-amplifier
-                |              |     +--ro actual-gain           l0-\
-\types:power-gain-or-null
-                |              |     +--ro in-voa?               l0-\
-\types:power-loss-or-null
-                |              |     +--ro out-voa?              l0-\
-\types:power-loss-or-null
-                |              |     +--ro tilt-target           l0-\
-\types:decimal-2-or-null
-                |              |     +--ro total-output-power    l0-\
-\types:power-dbm-or-null
-                |              |     +--ro raman-direction?      enu\
-\meration
+                |              |     +--ro actual-gain
+                |              |     |       l0-types:power-gain-or-\
+null
+                |              |     +--ro in-voa?
+                |              |     |       l0-types:power-loss-or-\
+null
+                |              |     +--ro out-voa?
+                |              |     |       l0-types:power-loss-or-\
+null
+                |              |     +--ro tilt-target
+                |              |     |       l0-types:decimal-2-or-n\
+ull
+                |              |     +--ro total-output-power
+                |              |     |       l0-types:power-dbm-or-n\
+ull
+                |              |     +--ro raman-direction?
+                |              |     |       enumeration
                 |              |     +--ro raman-pump* []
-                |              |        +--ro frequency?   l0-types:\
-\frequency-thz
-                |              |        +--ro power?       l0-types:\
-\decimal-2-or-null
+                |              |        +--ro frequency?
+                |              |        |       l0-types:frequency-t\
+hz
+                |              |        +--ro power?
+                |              |                l0-types:decimal-2-o\
+r-null
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
                 |                    +--ro media-channel-groups
                 |                       +--ro media-channel-group* []
                 |                          +--ro media-channels* []
-                |                             +--ro flexi-n?       l\
-\0-types:flexi-n
-                |                             +--ro flexi-m?       l\
-\0-types:flexi-m
-                |                             +--ro delta-power?   l\
-\0-types:power-ratio-or-null
+                |                             +--ro flexi-n?
+                |                             |       l0-types:flexi\
+-n
+                |                             +--ro flexi-m?
+                |                             |       l0-types:flexi\
+-m
+                |                             +--ro delta-power?
+                |                                     l0-types:power\
+-ratio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string
-                |     +--ro length          l0-types:decimal-2-or-nu\
-\ll
-                |     +--ro loss-coef       l0-types:decimal-2-or-nu\
-\ll
-                |     +--ro total-loss      l0-types:power-loss-or-n\
-\ull
-                |     +--ro pmd?            l0-types:decimal-2-or-nu\
-\ll
-                |     +--ro conn-in?        l0-types:power-loss-or-n\
-\ull
-                |     +--ro conn-out?       l0-types:power-loss-or-n\
-\ull
+                |     +--ro length
+                |     |       l0-types:decimal-2-or-null
+                |     +--ro loss-coef
+                |     |       l0-types:decimal-2-or-null
+                |     +--ro total-loss
+                |     |       l0-types:power-loss-or-null
+                |     +--ro pmd?
+                |     |       l0-types:decimal-2-or-null
+                |     +--ro conn-in?
+                |     |       l0-types:power-loss-or-null
+                |     +--ro conn-out?
+                |             l0-types:power-loss-or-null
                 +--:(concentratedloss)
                    +--ro concentratedloss
                       +--ro loss    l0-types:power-loss-or-null
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-terminat\
-\ion-point:
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:tunnel-termination-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
-       +--ro transponder-ref    -> ../../../../transponders/transpon\
-\der/transponder-id
-       +--ro transceiver-ref    -> ../../../../transponders/transpon\
-\der[transponder-id=current()/../transponder-ref]/transceiver/transc\
-\eiver-id
+       +--ro transponder-ref
+       |       -> ../../../../transponders/transponder/transponder-id
+       +--ro transceiver-ref    leafref
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw protection-type?   identityref
-  augment /nw:networks/nw:network/nw:node/nt:termination-point/tet:t\
-\e:
+  augment /nw:networks/nw:network/nw:node/nt:termination-point
+            /tet:te:
     +--rw inter-layer-sequence-number?   uint32
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
-\tes:
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-sou\
-\rce-entry/tet:connectivity-matrices:
-    +--ro roadm-path-impairments?   -> ../../../../../templates/road\
-\m-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-sou\
-\rce-entry/tet:connectivity-matrices/tet:connectivity-matrix:
-    +--ro roadm-path-impairments?   -> ../../../../../../templates/r\
-\oadm-path-impairments/roadm-path-impairment/roadm-path-impairments-\
-\id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
-\tes/tet:connectivity-matrices:
-    +--ro roadm-path-impairments?   -> ../../../../../templates/road\
-\m-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
-\tes/tet:connectivity-matrices/tet:connectivity-matrix:
-    +--ro roadm-path-impairments?   -> ../../../../../../templates/r\
-\oadm-path-impairments/roadm-path-impairment/roadm-path-impairments-\
-\id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
-\tes/tet:connectivity-matrices/tet:connectivity-matrix/tet:from:
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes:
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:information-source-entry/tet:connectivity-matrices:
+    +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:information-source-entry/tet:connectivity-matrices
+            /tet:connectivity-matrix:
+    +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes/tet:connectivity-matrices:
+    +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes/tet:connectivity-matrices
+            /tet:connectivity-matrix:
+    +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes/tet:connectivity-matrices
+            /tet:connectivity-matrix/tet:from:
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref                   -> ../../../../../../../nt:te\
-\rmination-point/tp-id
-       +--ro roadm-path-impairments?   -> ../../../../../../../../te\
-\mplates/roadm-path-impairments/roadm-path-impairment/roadm-path-imp\
-\airments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
-\tes/tet:connectivity-matrices/tet:connectivity-matrix/tet:to:
+       +--ro ltp-ref
+       |       -> ../../../../../../../nt:termination-point/tp-id
+       +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes/tet:connectivity-matrices
+            /tet:connectivity-matrix/tet:to:
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref                   -> ../../../../../../../nt:te\
-\rmination-point/tp-id
-       +--ro roadm-path-impairments?   -> ../../../../../../../../te\
-\mplates/roadm-path-impairments/roadm-path-impairment/roadm-path-imp\
-\airments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-terminat\
-\ion-point/tet:local-link-connectivities:
-    +--ro add-path-impairments?    -> ../../../../../templates/roadm\
-\-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-    +--ro drop-path-impairments?   -> ../../../../../templates/roadm\
-\-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-terminat\
-\ion-point/tet:local-link-connectivities/tet:local-link-connectivity:
-    +--ro add-path-impairments?    -> ../../../../../../templates/ro\
-\adm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-    +--ro drop-path-impairments?   -> ../../../../../../templates/ro\
-\adm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+       +--ro ltp-ref
+       |       -> ../../../../../../../nt:termination-point/tp-id
+       +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:tunnel-termination-point
+            /tet:local-link-connectivities:
+    +--ro add-path-impairments?    leafref
+    +--ro drop-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:tunnel-termination-point
+            /tet:local-link-connectivities
+            /tet:local-link-connectivity:
+    +--ro add-path-impairments?    leafref
+    +--ro drop-path-impairments?   leafref
     +--ro llc-transceiver* [ttp-transponder-ref ttp-transceiver-ref]
-    |  +--ro ttp-transponder-ref      -> ../../../../ttp-transceiver\
-\/transponder-ref
-    |  +--ro ttp-transceiver-ref      -> ../../../../ttp-transceiver\
-\/transceiver-ref
+    |  +--ro ttp-transponder-ref
+    |  |       -> ../../../../ttp-transceiver/transponder-ref
+    |  +--ro ttp-transceiver-ref
+    |  |       -> ../../../../ttp-transceiver/transceiver-ref
     |  +--ro is-allowed?              boolean
-    |  +--ro add-path-impairments?    -> ../../../../../../../templa\
-\tes/roadm-path-impairments/roadm-path-impairment/roadm-path-impairm\
-\ents-id
-    |  +--ro drop-path-impairments?   -> ../../../../../../../templa\
-\tes/roadm-path-impairments/roadm-path-impairment/roadm-path-impairm\
-\ents-id
+    |  +--ro add-path-impairments?    leafref
+    |  +--ro drop-path-impairments?   leafref
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref                  -> ../../../../../../nt:termin\
-\ation-point/tp-id
-       +--ro add-path-impairments?    -> ../../../../../../../templa\
-\tes/roadm-path-impairments/roadm-path-impairment/roadm-path-impairm\
-\ents-id
-       +--ro drop-path-impairments?   -> ../../../../../../../templa\
-\tes/roadm-path-impairments/roadm-path-impairment/roadm-path-impairm\
-\ents-id
+       +--ro ltp-ref
+       |       -> ../../../../../../nt:termination-point/tp-id
+       +--ro add-path-impairments?    leafref
+       +--ro drop-path-impairments?   leafref

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -1,4 +1,4 @@
-=============== NOTE: '\' line wrapping per RFC 8792 ================
+=============== NOTE: '\\' line wrapping per RFC 8792 ===============
 
 module: ietf-optical-impairment-topology
 
@@ -6,12 +6,79 @@ module: ietf-optical-impairment-topology
     +--rw optical-impairment-topology!
   augment /nw:networks/nw:network:
     +--rw otsis!
-       +--ro otsi-group* [otsi-group-id]
-          +--ro otsi-group-id    string
-          +--ro otsi* [otsi-carrier-id]
-             +--ro otsi-carrier-id           uint16
-             +--ro otsi-carrier-frequency?   union
-             +--ro e2e-mc-path-id*           uint16
+    |  +--ro otsi-group* [otsi-group-id]
+    |     +--ro otsi-group-id    string
+    |     +--ro otsi* [otsi-carrier-id]
+    |        +--ro otsi-carrier-id           uint16
+    |        +--ro otsi-carrier-frequency?   union
+    |        +--ro e2e-mc-path-id*           uint16
+    +--rw templates
+       +--rw roadm-path-impairments
+          +--ro roadm-path-impairment* [roadm-path-impairments-id]
+             +--ro roadm-path-impairments-id    string
+             +--ro (impairment-type)?
+                +--:(roadm-express-path)
+                |  +--ro roadm-express-path* []
+                |     +--ro frequency-range
+                |     |  +--ro lower-frequency    frequency-thz
+                |     |  +--ro upper-frequency    frequency-thz
+                |     +--ro roadm-pmd?                union
+                |     +--ro roadm-cd?                 l0-types:decim\
+\al-5-or-null
+                |     +--ro roadm-pdl?                l0-types:power\
+\-loss-or-null
+                |     +--ro roadm-inband-crosstalk?   l0-types:decim\
+\al-2-or-null
+                |     +--ro roadm-maxloss?            l0-types:power\
+\-loss-or-null
+                +--:(roadm-add-path)
+                |  +--ro roadm-add-path* []
+                |     +--ro frequency-range
+                |     |  +--ro lower-frequency    frequency-thz
+                |     |  +--ro upper-frequency    frequency-thz
+                |     +--ro roadm-pmd?                union
+                |     +--ro roadm-cd?                 l0-types:decim\
+\al-5-or-null
+                |     +--ro roadm-pdl?                l0-types:power\
+\-loss-or-null
+                |     +--ro roadm-inband-crosstalk?   l0-types:decim\
+\al-2-or-null
+                |     +--ro roadm-maxloss?            l0-types:power\
+\-loss-or-null
+                |     +--ro roadm-pmax?               l0-types:power\
+\-dbm-or-null
+                |     +--ro roadm-osnr?               l0-types:snr-o\
+\r-null
+                |     +--ro roadm-noise-figure?       l0-types:decim\
+\al-5-or-null
+                +--:(roadm-drop-path)
+                   +--ro roadm-drop-path* []
+                      +--ro frequency-range
+                      |  +--ro lower-frequency    frequency-thz
+                      |  +--ro upper-frequency    frequency-thz
+                      +--ro roadm-pmd?                union
+                      +--ro roadm-cd?                 l0-types:decim\
+\al-5-or-null
+                      +--ro roadm-pdl?                l0-types:power\
+\-loss-or-null
+                      +--ro roadm-inband-crosstalk?   l0-types:decim\
+\al-2-or-null
+                      +--ro roadm-maxloss?            l0-types:power\
+\-loss-or-null
+                      +--ro roadm-minloss?            l0-types:power\
+\-loss-or-null
+                      +--ro roadm-typloss?            l0-types:power\
+\-loss-or-null
+                      +--ro roadm-pmin?               l0-types:power\
+\-dbm-or-null
+                      +--ro roadm-pmax?               l0-types:power\
+\-dbm-or-null
+                      +--ro roadm-ptyp?               l0-types:power\
+\-dbm-or-null
+                      +--ro roadm-osnr?               l0-types:snr-o\
+\r-null
+                      +--ro roadm-noise-figure?       l0-types:decim\
+\al-5-or-null
   augment /nw:networks/nw:network/nw:node:
     +--rw transponders!
     |  +--ro transponder* [transponder-id]
@@ -25,15 +92,15 @@ module: ietf-optical-impairment-topology
     |        |     +--ro mode-id                         string
     |        |     +--ro (mode)
     |        |        +--:(G.698.2)
-    |        |        |  +--ro standard-mode?
-    |        |        |  |       standard-mode
+    |        |        |  +--ro standard-mode?            standard-mo\
+\de
     |        |        |  +--ro line-coding-bitrate*      identityref
-    |        |        |  +--ro min-central-frequency?
-    |        |        |  |       frequency-thz
-    |        |        |  +--ro max-central-frequency?
-    |        |        |  |       frequency-thz
-    |        |        |  +--ro transceiver-tunability?
-    |        |        |  |       frequency-ghz
+    |        |        |  +--ro min-central-frequency?    frequency-t\
+\hz
+    |        |        |  +--ro max-central-frequency?    frequency-t\
+\hz
+    |        |        |  +--ro transceiver-tunability?   frequency-g\
+\hz
     |        |        |  +--ro tx-channel-power-min?     power-dbm
     |        |        |  +--ro tx-channel-power-max?     power-dbm
     |        |        |  +--ro rx-channel-power-min?     power-dbm
@@ -41,125 +108,131 @@ module: ietf-optical-impairment-topology
     |        |        |  +--ro rx-total-power-max?       power-dbm
     |        |        +--:(organizational-mode)
     |        |        |  +--ro organizational-mode
-    |        |        |     +--ro operational-mode?
-    |        |        |     |       operational-mode
-    |        |        |     +--ro organization-identifier?
-    |        |        |     |       organization-identifier
-    |        |        |     +--ro line-coding-bitrate*
-    |        |        |     |       identityref
-    |        |        |     +--ro min-central-frequency?
-    |        |        |     |       frequency-thz
-    |        |        |     +--ro max-central-frequency?
-    |        |        |     |       frequency-thz
-    |        |        |     +--ro transceiver-tunability?
-    |        |        |     |       frequency-ghz
-    |        |        |     +--ro tx-channel-power-min?
-    |        |        |     |       power-dbm
-    |        |        |     +--ro tx-channel-power-max?
-    |        |        |     |       power-dbm
-    |        |        |     +--ro rx-channel-power-min?
-    |        |        |     |       power-dbm
-    |        |        |     +--ro rx-channel-power-max?
-    |        |        |     |       power-dbm
-    |        |        |     +--ro rx-total-power-max?
-    |        |        |             power-dbm
+    |        |        |     +--ro operational-mode?          operati\
+\onal-mode
+    |        |        |     +--ro organization-identifier?   organiz\
+\ation-identifier
+    |        |        |     +--ro line-coding-bitrate*       identit\
+\yref
+    |        |        |     +--ro min-central-frequency?     frequen\
+\cy-thz
+    |        |        |     +--ro max-central-frequency?     frequen\
+\cy-thz
+    |        |        |     +--ro transceiver-tunability?    frequen\
+\cy-ghz
+    |        |        |     +--ro tx-channel-power-min?      power-d\
+\bm
+    |        |        |     +--ro tx-channel-power-max?      power-d\
+\bm
+    |        |        |     +--ro rx-channel-power-min?      power-d\
+\bm
+    |        |        |     +--ro rx-channel-power-max?      power-d\
+\bm
+    |        |        |     +--ro rx-total-power-max?        power-d\
+\bm
     |        |        +--:(explicit-mode)
     |        |           +--ro explicit-mode
-    |        |              +--ro line-coding-bitrate?
-    |        |              |       identityref
-    |        |              +--ro bitrate?
-    |        |              |       uint16
-    |        |              +--ro max-diff-group-delay?
-    |        |              |       uint32
-    |        |              +--ro max-chromatic-dispersion?
-    |        |              |       decimal64
+    |        |              +--ro line-coding-bitrate?              \
+\  identityref
+    |        |              +--ro bitrate?                          \
+\  uint16
+    |        |              +--ro max-diff-group-delay?             \
+\  uint32
+    |        |              +--ro max-chromatic-dispersion?         \
+\  decimal64
     |        |              +--ro cd-penalty* []
     |        |              |  +--ro cd-value         union
     |        |              |  +--ro penalty-value    union
-    |        |              +--ro max-polarization-mode-dispersion?
-    |        |              |       decimal64
+    |        |              +--ro max-polarization-mode-dispersion? \
+\  decimal64
     |        |              +--ro pmd-penalty* []
     |        |              |  +--ro pmd-value        union
     |        |              |  +--ro penalty-value    union
-    |        |              +--ro max-polarization-dependant-loss
-    |        |              |       power-loss-or-null
+    |        |              +--ro max-polarization-dependant-loss   \
+\  power-loss-or-null
     |        |              +--ro pdl-penalty* []
-    |        |              |  +--ro pdl-value
-    |        |              |  |       power-loss-or-null
+    |        |              |  +--ro pdl-value        power-loss-or-\
+\null
     |        |              |  +--ro penalty-value    union
-    |        |              +--ro available-modulation-type?
-    |        |              |       identityref
-    |        |              +--ro min-OSNR?
-    |        |              |       snr
-    |        |              +--ro rx-ref-channel-power?
-    |        |              |       power-dbm
+    |        |              +--ro available-modulation-type?        \
+\  identityref
+    |        |              +--ro min-OSNR?                         \
+\  snr
+    |        |              +--ro rx-ref-channel-power?             \
+\  power-dbm
     |        |              +--ro rx-channel-power-penalty* []
-    |        |              |  +--ro rx-channel-power-value
-    |        |              |  |       power-dbm-or-null
+    |        |              |  +--ro rx-channel-power-value    power\
+\-dbm-or-null
     |        |              |  +--ro penalty-value             union
-    |        |              +--ro min-Q-factor?
-    |        |              |       int32
-    |        |              +--ro available-baud-rate?
-    |        |              |       uint32
-    |        |              +--ro roll-off?
-    |        |              |       decimal64
-    |        |              +--ro min-carrier-spacing?
-    |        |              |       frequency-ghz
-    |        |              +--ro available-fec-type?
-    |        |              |       identityref
-    |        |              +--ro fec-code-rate?
-    |        |              |       decimal64
-    |        |              +--ro fec-threshold?
-    |        |              |       decimal64
-    |        |              +--ro in-band-osnr?
-    |        |              |       snr
-    |        |              +--ro out-of-band-osnr?
-    |        |              |       snr
-    |        |              +--ro tx-polarization-power-difference?
-    |        |              |       power-ratio
-    |        |              +--ro polarization-skew?
-    |        |              |       decimal64
-    |        |              +--ro min-central-frequency?
-    |        |              |       frequency-thz
-    |        |              +--ro max-central-frequency?
-    |        |              |       frequency-thz
-    |        |              +--ro transceiver-tunability?
-    |        |              |       frequency-ghz
-    |        |              +--ro tx-channel-power-min?
-    |        |              |       power-dbm
-    |        |              +--ro tx-channel-power-max?
-    |        |              |       power-dbm
-    |        |              +--ro rx-channel-power-min?
-    |        |              |       power-dbm
-    |        |              +--ro rx-channel-power-max?
-    |        |              |       power-dbm
-    |        |              +--ro rx-total-power-max?
-    |        |              |       power-dbm
+    |        |              +--ro min-Q-factor?                     \
+\  int32
+    |        |              +--ro available-baud-rate?              \
+\  uint32
+    |        |              +--ro roll-off?                         \
+\  decimal64
+    |        |              +--ro min-carrier-spacing?              \
+\  frequency-ghz
+    |        |              +--ro available-fec-type?               \
+\  identityref
+    |        |              +--ro fec-code-rate?                    \
+\  decimal64
+    |        |              +--ro fec-threshold?                    \
+\  decimal64
+    |        |              +--ro in-band-osnr?                     \
+\  snr
+    |        |              +--ro out-of-band-osnr?                 \
+\  snr
+    |        |              +--ro tx-polarization-power-difference? \
+\  power-ratio
+    |        |              +--ro polarization-skew?                \
+\  decimal64
+    |        |              +--ro min-central-frequency?            \
+\  frequency-thz
+    |        |              +--ro max-central-frequency?            \
+\  frequency-thz
+    |        |              +--ro transceiver-tunability?           \
+\  frequency-ghz
+    |        |              +--ro tx-channel-power-min?             \
+\  power-dbm
+    |        |              +--ro tx-channel-power-max?             \
+\  power-dbm
+    |        |              +--ro rx-channel-power-min?             \
+\  power-dbm
+    |        |              +--ro rx-channel-power-max?             \
+\  power-dbm
+    |        |              +--ro rx-total-power-max?               \
+\  power-dbm
     |        |              +--ro compatible-modes
-    |        |                 +--ro supported-application-codes*
-    |        |                 |       -> ../../../mode-id
-    |        |                 +--ro supported-organizational-modes*
-    |        |                         -> ../../../mode-id
+    |        |                 +--ro supported-application-codes*   \
+\   -> ../../../mode-id
+    |        |                 +--ro supported-organizational-modes*\
+\   -> ../../../mode-id
     |        +--ro configured-mode?               union
     |        +--ro line-coding-bitrate?           identityref
     |        +--ro tx-channel-power?              power-dbm-or-null
     |        +--ro rx-channel-power?              power-dbm-or-null
     |        +--ro rx-total-power?                power-dbm-or-null
     |        +--ro outgoing-otsi
-    |        |  +--ro otsi-group-ref?   leafref
-    |        |  +--ro otsi-ref?         leafref
+    |        |  +--ro otsi-group-ref?   -> ../../../../../../otsis/o\
+\tsi-group/otsi-group-id
+    |        |  +--ro otsi-ref?         -> ../../../../../../otsis/o\
+\tsi-group[otsi-group-id=current()/../otsi-group-ref]/otsi/otsi-carr\
+\ier-id
     |        +--ro incoming-otsi
-    |        |  +--ro otsi-group-ref?   leafref
-    |        |  +--ro otsi-ref?         leafref
+    |        |  +--ro otsi-group-ref?   -> ../../../../../../otsis/o\
+\tsi-group/otsi-group-id
+    |        |  +--ro otsi-ref?         -> ../../../../../../otsis/o\
+\tsi-group[otsi-group-id=current()/../otsi-group-ref]/otsi/otsi-carr\
+\ier-id
     |        +--ro configured-termination-type?   enumeration
     +--rw regen-groups!
        +--ro regen-group* [group-id]
           +--ro group-id           uint32
           +--ro regen-metric?      uint32
-          +--ro transponder-ref*
-                  -> ../../../transponders/transponder/transponder-id
-  augment /nw:networks/nw:network/nt:link/tet:te
-            /tet:te-link-attributes:
+          +--ro transponder-ref*   -> ../../../transponders/transpon\
+\der/transponder-id
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attribu\
+\tes:
     +--ro OMS-attributes
        +--ro generalized-snr?        l0-types:snr
        +--ro equalization-mode?      identityref
@@ -171,19 +244,27 @@ module: ietf-optical-impairment-topology
        |     +--ro media-channels* []
        |        +--ro flexi-n?          l0-types:flexi-n
        |        +--ro flexi-m?          l0-types:flexi-m
-       |        +--ro otsi-group-ref?   leafref
+       |        +--ro otsi-group-ref?   -> ../../../../../../../../o\
+\tsis/otsi-group/otsi-group-id
        |        +--ro otsi-ref* []
-       |        |  +--ro otsi-carrier-ref?   leafref
-       |        |  +--ro e2e-mc-path-ref*    leafref
+       |        |  +--ro otsi-carrier-ref?   -> ../../../../../../..\
+\/../../otsis/otsi-group[otsi-group-id=current()/../../otsi-group-re\
+\f]/otsi/otsi-carrier-id
+       |        |  +--ro e2e-mc-path-ref*    -> ../../../../../../..\
+\/../../otsis/otsi-group[otsi-group-id=current()/../../otsi-group-re\
+\f]/otsi[otsi-carrier-id=current()/../otsi-carrier-ref]/e2e-mc-path-\
+\id
        |        +--ro delta-power?      l0-types:power-ratio-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
              +--ro oms-element-uid?          union
              +--ro reverse-element-ref
-             |  +--ro link-ref?
-             |  |       -> ../../../../../../../../nt:link/link-id
-             |  +--ro oms-element-ref*   leafref
+             |  +--ro link-ref?          -> ../../../../../../../../\
+\nt:link/link-id
+             |  +--ro oms-element-ref*   -> ../../../../../../../../\
+\nt:link[nt:link-id=current()/../link-ref]/tet:te/te-link-attributes\
+\/OMS-attributes/OMS-elements/OMS-element/elt-index
              +--ro (element)
                 +--:(amplifier)
                 |  +--ro geolocation
@@ -194,213 +275,155 @@ module: ietf-optical-impairment-topology
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element* []
-                |           +--ro name?
-                |           |       string
-                |           +--ro type-variety?
-                |           |       string
-                |           +--ro is-dynamic-gain-equalyzer?
-                |           |       boolean
+                |           +--ro name?                           st\
+\ring
+                |           +--ro type-variety?                   st\
+\ring
+                |           +--ro is-dynamic-gain-equalyzer?      bo\
+\olean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
-                |           +--ro stage-order?
-                |           |       uint8
+                |           +--ro stage-order?                    ui\
+\nt8
                 |           +--ro power-param
                 |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
-                |           |     |  +--ro nominal-carrier-power
-                |           |     |          l0-types:power-dbm-or-n\
-ull
+                |           |     |  +--ro nominal-carrier-power    \
+\l0-types:power-dbm-or-null
                 |           |     +--:(power-spectral-density)
-                |           |        +--ro nominal-psd
-                |           |                l0-types:psd-or-null
-                |           +--ro pdl?
-                |           |       l0-types:power-loss-or-null
+                |           |        +--ro nominal-psd              \
+\l0-types:psd-or-null
+                |           +--ro pdl?                            l0\
+\-types:power-loss-or-null
                 |           +--ro (amplifier-element-type)
                 |              +--:(optical-amplifier)
                 |              |  +--ro optical-amplifier
-                |              |     +--ro actual-gain
-                |              |     |       l0-types:power-gain-or-\
-null
-                |              |     +--ro in-voa?
-                |              |     |       l0-types:power-loss-or-\
-null
-                |              |     +--ro out-voa?
-                |              |     |       l0-types:power-loss-or-\
-null
-                |              |     +--ro tilt-target
-                |              |     |       l0-types:decimal-2-or-n\
-ull
-                |              |     +--ro total-output-power
-                |              |     |       l0-types:power-dbm-or-n\
-ull
-                |              |     +--ro raman-direction?
-                |              |     |       enumeration
+                |              |     +--ro actual-gain           l0-\
+\types:power-gain-or-null
+                |              |     +--ro in-voa?               l0-\
+\types:power-loss-or-null
+                |              |     +--ro out-voa?              l0-\
+\types:power-loss-or-null
+                |              |     +--ro tilt-target           l0-\
+\types:decimal-2-or-null
+                |              |     +--ro total-output-power    l0-\
+\types:power-dbm-or-null
+                |              |     +--ro raman-direction?      enu\
+\meration
                 |              |     +--ro raman-pump* []
-                |              |        +--ro frequency?
-                |              |        |       l0-types:frequency-t\
-hz
-                |              |        +--ro power?
-                |              |                l0-types:decimal-2-o\
-r-null
+                |              |        +--ro frequency?   l0-types:\
+\frequency-thz
+                |              |        +--ro power?       l0-types:\
+\decimal-2-or-null
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
                 |                    +--ro media-channel-groups
                 |                       +--ro media-channel-group* []
                 |                          +--ro media-channels* []
-                |                             +--ro flexi-n?
-                |                             |       l0-types:flexi\
--n
-                |                             +--ro flexi-m?
-                |                             |       l0-types:flexi\
--m
-                |                             +--ro delta-power?
-                |                                     l0-types:power\
--ratio-or-null
+                |                             +--ro flexi-n?       l\
+\0-types:flexi-n
+                |                             +--ro flexi-m?       l\
+\0-types:flexi-m
+                |                             +--ro delta-power?   l\
+\0-types:power-ratio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string
-                |     +--ro length
-                |     |       l0-types:decimal-2-or-null
-                |     +--ro loss-coef
-                |     |       l0-types:decimal-2-or-null
-                |     +--ro total-loss
-                |     |       l0-types:power-loss-or-null
-                |     +--ro pmd?
-                |     |       l0-types:decimal-2-or-null
-                |     +--ro conn-in?
-                |     |       l0-types:power-loss-or-null
-                |     +--ro conn-out?
-                |             l0-types:power-loss-or-null
+                |     +--ro length          l0-types:decimal-2-or-nu\
+\ll
+                |     +--ro loss-coef       l0-types:decimal-2-or-nu\
+\ll
+                |     +--ro total-loss      l0-types:power-loss-or-n\
+\ull
+                |     +--ro pmd?            l0-types:decimal-2-or-nu\
+\ll
+                |     +--ro conn-in?        l0-types:power-loss-or-n\
+\ull
+                |     +--ro conn-out?       l0-types:power-loss-or-n\
+\ull
                 +--:(concentratedloss)
                    +--ro concentratedloss
                       +--ro loss    l0-types:power-loss-or-null
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:tunnel-termination-point:
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-terminat\
+\ion-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
-       +--ro transponder-ref
-       |       -> ../../../../transponders/transponder/transponder-id
-       +--ro transceiver-ref    leafref
+       +--ro transponder-ref    -> ../../../../transponders/transpon\
+\der/transponder-id
+       +--ro transceiver-ref    -> ../../../../transponders/transpon\
+\der[transponder-id=current()/../transponder-ref]/transceiver/transc\
+\eiver-id
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw protection-type?   identityref
-  augment /nw:networks/nw:network/nw:node/nt:termination-point
-            /tet:te:
+  augment /nw:networks/nw:network/nw:node/nt:termination-point/tet:t\
+\e:
     +--rw inter-layer-sequence-number?   uint32
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes:
-    +--ro roadm-path-impairments* [roadm-path-impairments-id]
-       +--ro roadm-path-impairments-id    uint32
-       +--ro (impairment-type)?
-          +--:(roadm-express-path)
-          |  +--ro roadm-express-path* []
-          |     +--ro frequency-range
-          |     |  +--ro lower-frequency    frequency-thz
-          |     |  +--ro upper-frequency    frequency-thz
-          |     +--ro roadm-pmd?                union
-          |     +--ro roadm-cd?
-          |     |       l0-types:decimal-5-or-null
-          |     +--ro roadm-pdl?
-          |     |       l0-types:power-loss-or-null
-          |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types:decimal-2-or-null
-          |     +--ro roadm-maxloss?
-          |             l0-types:power-loss-or-null
-          +--:(roadm-add-path)
-          |  +--ro roadm-add-path* []
-          |     +--ro frequency-range
-          |     |  +--ro lower-frequency    frequency-thz
-          |     |  +--ro upper-frequency    frequency-thz
-          |     +--ro roadm-pmd?                union
-          |     +--ro roadm-cd?
-          |     |       l0-types:decimal-5-or-null
-          |     +--ro roadm-pdl?
-          |     |       l0-types:power-loss-or-null
-          |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types:decimal-2-or-null
-          |     +--ro roadm-maxloss?
-          |     |       l0-types:power-loss-or-null
-          |     +--ro roadm-pmax?
-          |     |       l0-types:power-dbm-or-null
-          |     +--ro roadm-osnr?               l0-types:snr-or-null
-          |     +--ro roadm-noise-figure?
-          |             l0-types:decimal-5-or-null
-          +--:(roadm-drop-path)
-             +--ro roadm-drop-path* []
-                +--ro frequency-range
-                |  +--ro lower-frequency    frequency-thz
-                |  +--ro upper-frequency    frequency-thz
-                +--ro roadm-pmd?                union
-                +--ro roadm-cd?
-                |       l0-types:decimal-5-or-null
-                +--ro roadm-pdl?
-                |       l0-types:power-loss-or-null
-                +--ro roadm-inband-crosstalk?
-                |       l0-types:decimal-2-or-null
-                +--ro roadm-maxloss?
-                |       l0-types:power-loss-or-null
-                +--ro roadm-minloss?
-                |       l0-types:power-loss-or-null
-                +--ro roadm-typloss?
-                |       l0-types:power-loss-or-null
-                +--ro roadm-pmin?
-                |       l0-types:power-dbm-or-null
-                +--ro roadm-pmax?
-                |       l0-types:power-dbm-or-null
-                +--ro roadm-ptyp?
-                |       l0-types:power-dbm-or-null
-                +--ro roadm-osnr?               l0-types:snr-or-null
-                +--ro roadm-noise-figure?
-                        l0-types:decimal-5-or-null
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:information-source-entry/tet:connectivity-matrices:
-    +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:information-source-entry/tet:connectivity-matrices
-            /tet:connectivity-matrix:
-    +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes/tet:connectivity-matrices:
-    +--ro roadm-path-impairments?
-            -> ../../roadm-path-impairments/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes/tet:connectivity-matrices
-            /tet:connectivity-matrix:
-    +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes/tet:connectivity-matrices
-            /tet:connectivity-matrix/tet:from:
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
+\tes:
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-sou\
+\rce-entry/tet:connectivity-matrices:
+    +--ro roadm-path-impairments?   -> ../../../../../templates/road\
+\m-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-sou\
+\rce-entry/tet:connectivity-matrices/tet:connectivity-matrix:
+    +--ro roadm-path-impairments?   -> ../../../../../../templates/r\
+\oadm-path-impairments/roadm-path-impairment/roadm-path-impairments-\
+\id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
+\tes/tet:connectivity-matrices:
+    +--ro roadm-path-impairments?   -> ../../../../../templates/road\
+\m-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
+\tes/tet:connectivity-matrices/tet:connectivity-matrix:
+    +--ro roadm-path-impairments?   -> ../../../../../../templates/r\
+\oadm-path-impairments/roadm-path-impairment/roadm-path-impairments-\
+\id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
+\tes/tet:connectivity-matrices/tet:connectivity-matrix/tet:from:
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref
-       |       -> ../../../../../../../nt:termination-point/tp-id
-       +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes/tet:connectivity-matrices
-            /tet:connectivity-matrix/tet:to:
+       +--ro ltp-ref                   -> ../../../../../../../nt:te\
+\rmination-point/tp-id
+       +--ro roadm-path-impairments?   -> ../../../../../../../../te\
+\mplates/roadm-path-impairments/roadm-path-impairment/roadm-path-imp\
+\airments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attribu\
+\tes/tet:connectivity-matrices/tet:connectivity-matrix/tet:to:
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref
-       |       -> ../../../../../../../nt:termination-point/tp-id
-       +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:tunnel-termination-point
-            /tet:local-link-connectivities:
-    +--ro add-path-impairments?    leafref
-    +--ro drop-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:tunnel-termination-point
-            /tet:local-link-connectivities
-            /tet:local-link-connectivity:
-    +--ro add-path-impairments?    leafref
-    +--ro drop-path-impairments?   leafref
+       +--ro ltp-ref                   -> ../../../../../../../nt:te\
+\rmination-point/tp-id
+       +--ro roadm-path-impairments?   -> ../../../../../../../../te\
+\mplates/roadm-path-impairments/roadm-path-impairment/roadm-path-imp\
+\airments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-terminat\
+\ion-point/tet:local-link-connectivities:
+    +--ro add-path-impairments?    -> ../../../../../templates/roadm\
+\-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+    +--ro drop-path-impairments?   -> ../../../../../templates/roadm\
+\-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-terminat\
+\ion-point/tet:local-link-connectivities/tet:local-link-connectivity:
+    +--ro add-path-impairments?    -> ../../../../../../templates/ro\
+\adm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+    +--ro drop-path-impairments?   -> ../../../../../../templates/ro\
+\adm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
     +--ro llc-transceiver* [ttp-transponder-ref ttp-transceiver-ref]
-    |  +--ro ttp-transponder-ref
-    |  |       -> ../../../../ttp-transceiver/transponder-ref
-    |  +--ro ttp-transceiver-ref
-    |  |       -> ../../../../ttp-transceiver/transceiver-ref
+    |  +--ro ttp-transponder-ref      -> ../../../../ttp-transceiver\
+\/transponder-ref
+    |  +--ro ttp-transceiver-ref      -> ../../../../ttp-transceiver\
+\/transceiver-ref
     |  +--ro is-allowed?              boolean
-    |  +--ro add-path-impairments?    leafref
-    |  +--ro drop-path-impairments?   leafref
+    |  +--ro add-path-impairments?    -> ../../../../../../../templa\
+\tes/roadm-path-impairments/roadm-path-impairment/roadm-path-impairm\
+\ents-id
+    |  +--ro drop-path-impairments?   -> ../../../../../../../templa\
+\tes/roadm-path-impairments/roadm-path-impairment/roadm-path-impairm\
+\ents-id
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref
-       |       -> ../../../../../../nt:termination-point/tp-id
-       +--ro add-path-impairments?    leafref
-       +--ro drop-path-impairments?   leafref
+       +--ro ltp-ref                  -> ../../../../../../nt:termin\
+\ation-point/tp-id
+       +--ro add-path-impairments?    -> ../../../../../../../templa\
+\tes/roadm-path-impairments/roadm-path-impairment/roadm-path-impairm\
+\ents-id
+       +--ro drop-path-impairments?   -> ../../../../../../../templa\
+\tes/roadm-path-impairments/roadm-path-impairment/roadm-path-impairm\
+\ents-id

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -21,42 +21,65 @@ module: ietf-optical-impairment-topology
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
        |        |     +--ro roadm-pmd?                union
-       |        |     +--ro roadm-cd?                 l0-types:decimal-5-or-null
-       |        |     +--ro roadm-pdl?                l0-types:power-loss-or-null
-       |        |     +--ro roadm-inband-crosstalk?   l0-types:decimal-2-or-null
-       |        |     +--ro roadm-maxloss?            l0-types:power-loss-or-null
+       |        |     +--ro roadm-cd?
+       |        |     |       l0-types:decimal-5-or-null
+       |        |     +--ro roadm-pdl?
+       |        |     |       l0-types:power-loss-or-null
+       |        |     +--ro roadm-inband-crosstalk?
+       |        |     |       l0-types:decimal-2-or-null
+       |        |     +--ro roadm-maxloss?
+       |        |             l0-types:power-loss-or-null
        |        +--:(roadm-add-path)
        |        |  +--ro roadm-add-path* []
        |        |     +--ro frequency-range
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
        |        |     +--ro roadm-pmd?                union
-       |        |     +--ro roadm-cd?                 l0-types:decimal-5-or-null
-       |        |     +--ro roadm-pdl?                l0-types:power-loss-or-null
-       |        |     +--ro roadm-inband-crosstalk?   l0-types:decimal-2-or-null
-       |        |     +--ro roadm-maxloss?            l0-types:power-loss-or-null
-       |        |     +--ro roadm-pmax?               l0-types:power-dbm-or-null
-       |        |     +--ro roadm-osnr?               l0-types:snr-or-null
-       |        |     +--ro roadm-noise-figure?       l0-types:decimal-5-or-null
+       |        |     +--ro roadm-cd?
+       |        |     |       l0-types:decimal-5-or-null
+       |        |     +--ro roadm-pdl?
+       |        |     |       l0-types:power-loss-or-null
+       |        |     +--ro roadm-inband-crosstalk?
+       |        |     |       l0-types:decimal-2-or-null
+       |        |     +--ro roadm-maxloss?
+       |        |     |       l0-types:power-loss-or-null
+       |        |     +--ro roadm-pmax?
+       |        |     |       l0-types:power-dbm-or-null
+       |        |     +--ro roadm-osnr?
+       |        |     |       l0-types:snr-or-null
+       |        |     +--ro roadm-noise-figure?
+       |        |             l0-types:decimal-5-or-null
        |        +--:(roadm-drop-path)
        |           +--ro roadm-drop-path* []
        |              +--ro frequency-range
        |              |  +--ro lower-frequency    frequency-thz
        |              |  +--ro upper-frequency    frequency-thz
        |              +--ro roadm-pmd?                union
-       |              +--ro roadm-cd?                 l0-types:decimal-5-or-null
-       |              +--ro roadm-pdl?                l0-types:power-loss-or-null
-       |              +--ro roadm-inband-crosstalk?   l0-types:decimal-2-or-null
-       |              +--ro roadm-maxloss?            l0-types:power-loss-or-null
-       |              +--ro roadm-minloss?            l0-types:power-loss-or-null
-       |              +--ro roadm-typloss?            l0-types:power-loss-or-null
-       |              +--ro roadm-pmin?               l0-types:power-dbm-or-null
-       |              +--ro roadm-pmax?               l0-types:power-dbm-or-null
-       |              +--ro roadm-ptyp?               l0-types:power-dbm-or-null
-       |              +--ro roadm-osnr?               l0-types:snr-or-null
-       |              +--ro roadm-noise-figure?       l0-types:decimal-5-or-null
+       |              +--ro roadm-cd?
+       |              |       l0-types:decimal-5-or-null
+       |              +--ro roadm-pdl?
+       |              |       l0-types:power-loss-or-null
+       |              +--ro roadm-inband-crosstalk?
+       |              |       l0-types:decimal-2-or-null
+       |              +--ro roadm-maxloss?
+       |              |       l0-types:power-loss-or-null
+       |              +--ro roadm-minloss?
+       |              |       l0-types:power-loss-or-null
+       |              +--ro roadm-typloss?
+       |              |       l0-types:power-loss-or-null
+       |              +--ro roadm-pmin?
+       |              |       l0-types:power-dbm-or-null
+       |              +--ro roadm-pmax?
+       |              |       l0-types:power-dbm-or-null
+       |              +--ro roadm-ptyp?
+       |              |       l0-types:power-dbm-or-null
+       |              +--ro roadm-osnr?
+       |              |       l0-types:snr-or-null
+       |              +--ro roadm-noise-figure?
+       |                      l0-types:decimal-5-or-null
        +--ro explicit-transceiver-modes
-          +--ro explicit-transceiver-mode* [explicit-transceiver-mode-id]
+          +--ro explicit-transceiver-mode*
+                  [explicit-transceiver-mode-id]
              +--ro explicit-transceiver-mode-id        string
              +--ro line-coding-bitrate?                identityref
              +--ro bitrate?                            uint16
@@ -69,7 +92,8 @@ module: ietf-optical-impairment-topology
              +--ro pmd-penalty* []
              |  +--ro pmd-value        union
              |  +--ro penalty-value    union
-             +--ro max-polarization-dependant-loss     power-loss-or-null
+             +--ro max-polarization-dependant-loss
+             |       power-loss-or-null
              +--ro pdl-penalty* []
              |  +--ro pdl-value        power-loss-or-null
              |  +--ro penalty-value    union
@@ -103,11 +127,15 @@ module: ietf-optical-impairment-topology
     |        |     +--ro mode-id                         string
     |        |     +--ro (mode)
     |        |        +--:(G.698.2)
-    |        |        |  +--ro standard-mode?            standard-mode
+    |        |        |  +--ro standard-mode?
+    |        |        |  |       standard-mode
     |        |        |  +--ro line-coding-bitrate*      identityref
-    |        |        |  +--ro min-central-frequency?    frequency-thz
-    |        |        |  +--ro max-central-frequency?    frequency-thz
-    |        |        |  +--ro transceiver-tunability?   frequency-ghz
+    |        |        |  +--ro min-central-frequency?
+    |        |        |  |       frequency-thz
+    |        |        |  +--ro max-central-frequency?
+    |        |        |  |       frequency-thz
+    |        |        |  +--ro transceiver-tunability?
+    |        |        |  |       frequency-ghz
     |        |        |  +--ro tx-channel-power-min?     power-dbm
     |        |        |  +--ro tx-channel-power-max?     power-dbm
     |        |        |  +--ro rx-channel-power-min?     power-dbm
@@ -115,49 +143,73 @@ module: ietf-optical-impairment-topology
     |        |        |  +--ro rx-total-power-max?       power-dbm
     |        |        +--:(organizational-mode)
     |        |        |  +--ro organizational-mode
-    |        |        |     +--ro operational-mode?          operational-mode
-    |        |        |     +--ro organization-identifier?   organization-identifier
-    |        |        |     +--ro line-coding-bitrate*       identityref
-    |        |        |     +--ro min-central-frequency?     frequency-thz
-    |        |        |     +--ro max-central-frequency?     frequency-thz
-    |        |        |     +--ro transceiver-tunability?    frequency-ghz
-    |        |        |     +--ro tx-channel-power-min?      power-dbm
-    |        |        |     +--ro tx-channel-power-max?      power-dbm
-    |        |        |     +--ro rx-channel-power-min?      power-dbm
-    |        |        |     +--ro rx-channel-power-max?      power-dbm
-    |        |        |     +--ro rx-total-power-max?        power-dbm
+    |        |        |     +--ro operational-mode?
+    |        |        |     |       operational-mode
+    |        |        |     +--ro organization-identifier?
+    |        |        |     |       organization-identifier
+    |        |        |     +--ro line-coding-bitrate*
+    |        |        |     |       identityref
+    |        |        |     +--ro min-central-frequency?
+    |        |        |     |       frequency-thz
+    |        |        |     +--ro max-central-frequency?
+    |        |        |     |       frequency-thz
+    |        |        |     +--ro transceiver-tunability?
+    |        |        |     |       frequency-ghz
+    |        |        |     +--ro tx-channel-power-min?
+    |        |        |     |       power-dbm
+    |        |        |     +--ro tx-channel-power-max?
+    |        |        |     |       power-dbm
+    |        |        |     +--ro rx-channel-power-min?
+    |        |        |     |       power-dbm
+    |        |        |     +--ro rx-channel-power-max?
+    |        |        |     |       power-dbm
+    |        |        |     +--ro rx-total-power-max?
+    |        |        |             power-dbm
     |        |        +--:(explicit-mode)
     |        |           +--ro explicit-mode
-    |        |              +--ro min-central-frequency?           frequency-thz
-    |        |              +--ro max-central-frequency?           frequency-thz
-    |        |              +--ro transceiver-tunability?          frequency-ghz
-    |        |              +--ro tx-channel-power-min?            power-dbm
-    |        |              +--ro tx-channel-power-max?            power-dbm
-    |        |              +--ro rx-channel-power-min?            power-dbm
-    |        |              +--ro rx-channel-power-max?            power-dbm
-    |        |              +--ro rx-total-power-max?              power-dbm
+    |        |              +--ro min-central-frequency?
+    |        |              |       frequency-thz
+    |        |              +--ro max-central-frequency?
+    |        |              |       frequency-thz
+    |        |              +--ro transceiver-tunability?
+    |        |              |       frequency-ghz
+    |        |              +--ro tx-channel-power-min?
+    |        |              |       power-dbm
+    |        |              +--ro tx-channel-power-max?
+    |        |              |       power-dbm
+    |        |              +--ro rx-channel-power-min?
+    |        |              |       power-dbm
+    |        |              +--ro rx-channel-power-max?
+    |        |              |       power-dbm
+    |        |              +--ro rx-total-power-max?
+    |        |              |       power-dbm
     |        |              +--ro compatible-modes
-    |        |              |  +--ro supported-application-codes*      -> ../../../mode-id
-    |        |              |  +--ro supported-organizational-modes*   -> ../../../mode-id
-    |        |              +--ro explicit-transceiver-mode-ref?   -> ../../../../../../../../templates/explicit-transceiver-modes/explicit-transceiver-mode/explicit-transceiver-mode-id
+    |        |              |  +--ro supported-application-codes*
+    |        |              |  |       -> ../../../mode-id
+    |        |              |  +--ro supported-organizational-modes*
+    |        |              |          -> ../../../mode-id
+    |        |              +--ro explicit-transceiver-mode-ref?
+    |        |                      leafref
     |        +--ro configured-mode?               union
     |        +--ro line-coding-bitrate?           identityref
     |        +--ro tx-channel-power?              power-dbm-or-null
     |        +--ro rx-channel-power?              power-dbm-or-null
     |        +--ro rx-total-power?                power-dbm-or-null
     |        +--ro outgoing-otsi
-    |        |  +--ro otsi-group-ref?   -> ../../../../../../otsis/otsi-group/otsi-group-id
-    |        |  +--ro otsi-ref?         -> ../../../../../../otsis/otsi-group[otsi-group-id=current()/../otsi-group-ref]/otsi/otsi-carrier-id
+    |        |  +--ro otsi-group-ref?   leafref
+    |        |  +--ro otsi-ref?         leafref
     |        +--ro incoming-otsi
-    |        |  +--ro otsi-group-ref?   -> ../../../../../../otsis/otsi-group/otsi-group-id
-    |        |  +--ro otsi-ref?         -> ../../../../../../otsis/otsi-group[otsi-group-id=current()/../otsi-group-ref]/otsi/otsi-carrier-id
+    |        |  +--ro otsi-group-ref?   leafref
+    |        |  +--ro otsi-ref?         leafref
     |        +--ro configured-termination-type?   enumeration
     +--rw regen-groups!
        +--ro regen-group* [group-id]
           +--ro group-id           uint32
           +--ro regen-metric?      uint32
-          +--ro transponder-ref*   -> ../../../transponders/transponder/transponder-id
-  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes:
+          +--ro transponder-ref*
+                  -> ../../../transponders/transponder/transponder-id
+  augment /nw:networks/nw:network/nt:link/tet:te
+            /tet:te-link-attributes:
     +--ro OMS-attributes
        +--ro generalized-snr?        l0-types:snr
        +--ro equalization-mode?      identityref
@@ -169,18 +221,19 @@ module: ietf-optical-impairment-topology
        |     +--ro media-channels* []
        |        +--ro flexi-n?          l0-types:flexi-n
        |        +--ro flexi-m?          l0-types:flexi-m
-       |        +--ro otsi-group-ref?   -> ../../../../../../../../otsis/otsi-group/otsi-group-id
+       |        +--ro otsi-group-ref?   leafref
        |        +--ro otsi-ref* []
-       |        |  +--ro otsi-carrier-ref?   -> ../../../../../../../../../otsis/otsi-group[otsi-group-id=current()/../../otsi-group-ref]/otsi/otsi-carrier-id
-       |        |  +--ro e2e-mc-path-ref*    -> ../../../../../../../../../otsis/otsi-group[otsi-group-id=current()/../../otsi-group-ref]/otsi[otsi-carrier-id=current()/../otsi-carrier-ref]/e2e-mc-path-id
+       |        |  +--ro otsi-carrier-ref?   leafref
+       |        |  +--ro e2e-mc-path-ref*    leafref
        |        +--ro delta-power?      l0-types:power-ratio-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
              +--ro oms-element-uid?          union
              +--ro reverse-element-ref
-             |  +--ro link-ref?          -> ../../../../../../../../nt:link/link-id
-             |  +--ro oms-element-ref*   -> ../../../../../../../../nt:link[nt:link-id=current()/../link-ref]/tet:te/te-link-attributes/OMS-attributes/OMS-elements/OMS-element/elt-index
+             |  +--ro link-ref?
+             |  |       -> ../../../../../../../../nt:link/link-id
+             |  +--ro oms-element-ref*   leafref
              +--ro (element)
                 +--:(amplifier)
                 |  +--ro geolocation
@@ -191,90 +244,138 @@ module: ietf-optical-impairment-topology
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element* []
-                |           +--ro name?                           string
-                |           +--ro type-variety?                   string
-                |           +--ro is-dynamic-gain-equalyzer?      boolean
+                |           +--ro name?
+                |           |       string
+                |           +--ro type-variety?
+                |           |       string
+                |           +--ro is-dynamic-gain-equalyzer?
+                |           |       boolean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
-                |           +--ro stage-order?                    uint8
+                |           +--ro stage-order?
+                |           |       uint8
                 |           +--ro power-param
                 |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
-                |           |     |  +--ro nominal-carrier-power    l0-types:power-dbm-or-null
+                |           |     |  +--ro nominal-carrier-power
+                |           |     |          l0-types:power-dbm-or-null
                 |           |     +--:(power-spectral-density)
-                |           |        +--ro nominal-psd              l0-types:psd-or-null
-                |           +--ro pdl?                            l0-types:power-loss-or-null
+                |           |        +--ro nominal-psd
+                |           |                l0-types:psd-or-null
+                |           +--ro pdl?
+                |           |       l0-types:power-loss-or-null
                 |           +--ro (amplifier-element-type)
                 |              +--:(optical-amplifier)
                 |              |  +--ro optical-amplifier
-                |              |     +--ro actual-gain           l0-types:power-gain-or-null
-                |              |     +--ro in-voa?               l0-types:power-loss-or-null
-                |              |     +--ro out-voa?              l0-types:power-loss-or-null
-                |              |     +--ro tilt-target           l0-types:decimal-2-or-null
-                |              |     +--ro total-output-power    l0-types:power-dbm-or-null
-                |              |     +--ro raman-direction?      enumeration
+                |              |     +--ro actual-gain
+                |              |     |       l0-types:power-gain-or-null
+                |              |     +--ro in-voa?
+                |              |     |       l0-types:power-loss-or-null
+                |              |     +--ro out-voa?
+                |              |     |       l0-types:power-loss-or-null
+                |              |     +--ro tilt-target
+                |              |     |       l0-types:decimal-2-or-null
+                |              |     +--ro total-output-power
+                |              |     |       l0-types:power-dbm-or-null
+                |              |     +--ro raman-direction?
+                |              |     |       enumeration
                 |              |     +--ro raman-pump* []
-                |              |        +--ro frequency?   l0-types:frequency-thz
-                |              |        +--ro power?       l0-types:decimal-2-or-null
+                |              |        +--ro frequency?
+                |              |        |       l0-types:frequency-thz
+                |              |        +--ro power?
+                |              |                l0-types:decimal-2-or-null
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
                 |                    +--ro media-channel-groups
                 |                       +--ro media-channel-group* []
                 |                          +--ro media-channels* []
-                |                             +--ro flexi-n?       l0-types:flexi-n
-                |                             +--ro flexi-m?       l0-types:flexi-m
-                |                             +--ro delta-power?   l0-types:power-ratio-or-null
+                |                             +--ro flexi-n?
+                |                             |       l0-types:flexi-n
+                |                             +--ro flexi-m?
+                |                             |       l0-types:flexi-m
+                |                             +--ro delta-power?
+                |                                     l0-types:power-ratio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string
-                |     +--ro length          l0-types:decimal-2-or-null
-                |     +--ro loss-coef       l0-types:decimal-2-or-null
-                |     +--ro total-loss      l0-types:power-loss-or-null
-                |     +--ro pmd?            l0-types:decimal-2-or-null
-                |     +--ro conn-in?        l0-types:power-loss-or-null
-                |     +--ro conn-out?       l0-types:power-loss-or-null
+                |     +--ro length
+                |     |       l0-types:decimal-2-or-null
+                |     +--ro loss-coef
+                |     |       l0-types:decimal-2-or-null
+                |     +--ro total-loss
+                |     |       l0-types:power-loss-or-null
+                |     +--ro pmd?
+                |     |       l0-types:decimal-2-or-null
+                |     +--ro conn-in?
+                |     |       l0-types:power-loss-or-null
+                |     +--ro conn-out?
+                |             l0-types:power-loss-or-null
                 +--:(concentratedloss)
                    +--ro concentratedloss
                       +--ro loss    l0-types:power-loss-or-null
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point:
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:tunnel-termination-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
-       +--ro transponder-ref    -> ../../../../transponders/transponder/transponder-id
-       +--ro transceiver-ref    -> ../../../../transponders/transponder[transponder-id=current()/../transponder-ref]/transceiver/transceiver-id
+       +--ro transponder-ref
+       |       -> ../../../../transponders/transponder/transponder-id
+       +--ro transceiver-ref    leafref
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw protection-type?   identityref
-  augment /nw:networks/nw:network/nw:node/nt:termination-point/tet:te:
+  augment /nw:networks/nw:network/nw:node/nt:termination-point
+            /tet:te:
     +--rw inter-layer-sequence-number?   uint32
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes:
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices:
-    +--ro roadm-path-impairments?   -> ../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix:
-    +--ro roadm-path-impairments?   -> ../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices:
-    +--ro roadm-path-impairments?   -> ../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix:
-    +--ro roadm-path-impairments?   -> ../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:from:
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes:
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:information-source-entry/tet:connectivity-matrices:
+    +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:information-source-entry/tet:connectivity-matrices
+            /tet:connectivity-matrix:
+    +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes/tet:connectivity-matrices:
+    +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes/tet:connectivity-matrices
+            /tet:connectivity-matrix:
+    +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes/tet:connectivity-matrices
+            /tet:connectivity-matrix/tet:from:
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref                   -> ../../../../../../../nt:termination-point/tp-id
-       +--ro roadm-path-impairments?   -> ../../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:to:
+       +--ro ltp-ref
+       |       -> ../../../../../../../nt:termination-point/tp-id
+       +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:te-node-attributes/tet:connectivity-matrices
+            /tet:connectivity-matrix/tet:to:
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref                   -> ../../../../../../../nt:termination-point/tp-id
-       +--ro roadm-path-impairments?   -> ../../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities:
-    +--ro add-path-impairments?    -> ../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-    +--ro drop-path-impairments?   -> ../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity:
-    +--ro add-path-impairments?    -> ../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-    +--ro drop-path-impairments?   -> ../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+       +--ro ltp-ref
+       |       -> ../../../../../../../nt:termination-point/tp-id
+       +--ro roadm-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:tunnel-termination-point
+            /tet:local-link-connectivities:
+    +--ro add-path-impairments?    leafref
+    +--ro drop-path-impairments?   leafref
+  augment /nw:networks/nw:network/nw:node/tet:te
+            /tet:tunnel-termination-point
+            /tet:local-link-connectivities
+            /tet:local-link-connectivity:
+    +--ro add-path-impairments?    leafref
+    +--ro drop-path-impairments?   leafref
     +--ro llc-transceiver* [ttp-transponder-ref ttp-transceiver-ref]
-    |  +--ro ttp-transponder-ref      -> ../../../../ttp-transceiver/transponder-ref
-    |  +--ro ttp-transceiver-ref      -> ../../../../ttp-transceiver/transceiver-ref
+    |  +--ro ttp-transponder-ref
+    |  |       -> ../../../../ttp-transceiver/transponder-ref
+    |  +--ro ttp-transceiver-ref
+    |  |       -> ../../../../ttp-transceiver/transceiver-ref
     |  +--ro is-allowed?              boolean
-    |  +--ro add-path-impairments?    -> ../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-    |  +--ro drop-path-impairments?   -> ../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+    |  +--ro add-path-impairments?    leafref
+    |  +--ro drop-path-impairments?   leafref
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref                  -> ../../../../../../nt:termination-point/tp-id
-       +--ro add-path-impairments?    -> ../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
-       +--ro drop-path-impairments?   -> ../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+       +--ro ltp-ref
+       |       -> ../../../../../../nt:termination-point/tp-id
+       +--ro add-path-impairments?    leafref
+       +--ro drop-path-impairments?   leafref

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -4,12 +4,92 @@ module: ietf-optical-impairment-topology
     +--rw optical-impairment-topology!
   augment /nw:networks/nw:network:
     +--rw otsis!
-       +--ro otsi-group* [otsi-group-id]
-          +--ro otsi-group-id    string
-          +--ro otsi* [otsi-carrier-id]
-             +--ro otsi-carrier-id           uint16
-             +--ro otsi-carrier-frequency?   union
-             +--ro e2e-mc-path-id*           uint16
+    |  +--ro otsi-group* [otsi-group-id]
+    |     +--ro otsi-group-id    string
+    |     +--ro otsi* [otsi-carrier-id]
+    |        +--ro otsi-carrier-id           uint16
+    |        +--ro otsi-carrier-frequency?   union
+    |        +--ro e2e-mc-path-id*           uint16
+    +--ro templates
+       +--ro roadm-path-impairments
+       |  +--ro roadm-path-impairment* [roadm-path-impairments-id]
+       |     +--ro roadm-path-impairments-id    string
+       |     +--ro (impairment-type)?
+       |        +--:(roadm-express-path)
+       |        |  +--ro roadm-express-path* []
+       |        |     +--ro frequency-range
+       |        |     |  +--ro lower-frequency    frequency-thz
+       |        |     |  +--ro upper-frequency    frequency-thz
+       |        |     +--ro roadm-pmd?                union
+       |        |     +--ro roadm-cd?                 l0-types:decimal-5-or-null
+       |        |     +--ro roadm-pdl?                l0-types:power-loss-or-null
+       |        |     +--ro roadm-inband-crosstalk?   l0-types:decimal-2-or-null
+       |        |     +--ro roadm-maxloss?            l0-types:power-loss-or-null
+       |        +--:(roadm-add-path)
+       |        |  +--ro roadm-add-path* []
+       |        |     +--ro frequency-range
+       |        |     |  +--ro lower-frequency    frequency-thz
+       |        |     |  +--ro upper-frequency    frequency-thz
+       |        |     +--ro roadm-pmd?                union
+       |        |     +--ro roadm-cd?                 l0-types:decimal-5-or-null
+       |        |     +--ro roadm-pdl?                l0-types:power-loss-or-null
+       |        |     +--ro roadm-inband-crosstalk?   l0-types:decimal-2-or-null
+       |        |     +--ro roadm-maxloss?            l0-types:power-loss-or-null
+       |        |     +--ro roadm-pmax?               l0-types:power-dbm-or-null
+       |        |     +--ro roadm-osnr?               l0-types:snr-or-null
+       |        |     +--ro roadm-noise-figure?       l0-types:decimal-5-or-null
+       |        +--:(roadm-drop-path)
+       |           +--ro roadm-drop-path* []
+       |              +--ro frequency-range
+       |              |  +--ro lower-frequency    frequency-thz
+       |              |  +--ro upper-frequency    frequency-thz
+       |              +--ro roadm-pmd?                union
+       |              +--ro roadm-cd?                 l0-types:decimal-5-or-null
+       |              +--ro roadm-pdl?                l0-types:power-loss-or-null
+       |              +--ro roadm-inband-crosstalk?   l0-types:decimal-2-or-null
+       |              +--ro roadm-maxloss?            l0-types:power-loss-or-null
+       |              +--ro roadm-minloss?            l0-types:power-loss-or-null
+       |              +--ro roadm-typloss?            l0-types:power-loss-or-null
+       |              +--ro roadm-pmin?               l0-types:power-dbm-or-null
+       |              +--ro roadm-pmax?               l0-types:power-dbm-or-null
+       |              +--ro roadm-ptyp?               l0-types:power-dbm-or-null
+       |              +--ro roadm-osnr?               l0-types:snr-or-null
+       |              +--ro roadm-noise-figure?       l0-types:decimal-5-or-null
+       +--ro explicit-transceiver-modes
+          +--ro explicit-transceiver-mode* [explicit-transceiver-mode-id]
+             +--ro explicit-transceiver-mode-id        string
+             +--ro line-coding-bitrate?                identityref
+             +--ro bitrate?                            uint16
+             +--ro max-diff-group-delay?               uint32
+             +--ro max-chromatic-dispersion?           decimal64
+             +--ro cd-penalty* []
+             |  +--ro cd-value         union
+             |  +--ro penalty-value    union
+             +--ro max-polarization-mode-dispersion?   decimal64
+             +--ro pmd-penalty* []
+             |  +--ro pmd-value        union
+             |  +--ro penalty-value    union
+             +--ro max-polarization-dependant-loss     power-loss-or-null
+             +--ro pdl-penalty* []
+             |  +--ro pdl-value        power-loss-or-null
+             |  +--ro penalty-value    union
+             +--ro available-modulation-type?          identityref
+             +--ro min-OSNR?                           snr
+             +--ro rx-ref-channel-power?               power-dbm
+             +--ro rx-channel-power-penalty* []
+             |  +--ro rx-channel-power-value    power-dbm-or-null
+             |  +--ro penalty-value             union
+             +--ro min-Q-factor?                       int32
+             +--ro available-baud-rate?                uint32
+             +--ro roll-off?                           decimal64
+             +--ro min-carrier-spacing?                frequency-ghz
+             +--ro available-fec-type?                 identityref
+             +--ro fec-code-rate?                      decimal64
+             +--ro fec-threshold?                      decimal64
+             +--ro in-band-osnr?                       snr
+             +--ro out-of-band-osnr?                   snr
+             +--ro tx-polarization-power-difference?   power-ratio
+             +--ro polarization-skew?                  decimal64
   augment /nw:networks/nw:network/nw:node:
     +--rw transponders!
     |  +--ro transponder* [transponder-id]
@@ -23,15 +103,11 @@ module: ietf-optical-impairment-topology
     |        |     +--ro mode-id                         string
     |        |     +--ro (mode)
     |        |        +--:(G.698.2)
-    |        |        |  +--ro standard-mode?
-    |        |        |  |       standard-mode
+    |        |        |  +--ro standard-mode?            standard-mode
     |        |        |  +--ro line-coding-bitrate*      identityref
-    |        |        |  +--ro min-central-frequency?
-    |        |        |  |       frequency-thz
-    |        |        |  +--ro max-central-frequency?
-    |        |        |  |       frequency-thz
-    |        |        |  +--ro transceiver-tunability?
-    |        |        |  |       frequency-ghz
+    |        |        |  +--ro min-central-frequency?    frequency-thz
+    |        |        |  +--ro max-central-frequency?    frequency-thz
+    |        |        |  +--ro transceiver-tunability?   frequency-ghz
     |        |        |  +--ro tx-channel-power-min?     power-dbm
     |        |        |  +--ro tx-channel-power-max?     power-dbm
     |        |        |  +--ro rx-channel-power-min?     power-dbm
@@ -39,125 +115,49 @@ module: ietf-optical-impairment-topology
     |        |        |  +--ro rx-total-power-max?       power-dbm
     |        |        +--:(organizational-mode)
     |        |        |  +--ro organizational-mode
-    |        |        |     +--ro operational-mode?
-    |        |        |     |       operational-mode
-    |        |        |     +--ro organization-identifier?
-    |        |        |     |       organization-identifier
-    |        |        |     +--ro line-coding-bitrate*
-    |        |        |     |       identityref
-    |        |        |     +--ro min-central-frequency?
-    |        |        |     |       frequency-thz
-    |        |        |     +--ro max-central-frequency?
-    |        |        |     |       frequency-thz
-    |        |        |     +--ro transceiver-tunability?
-    |        |        |     |       frequency-ghz
-    |        |        |     +--ro tx-channel-power-min?
-    |        |        |     |       power-dbm
-    |        |        |     +--ro tx-channel-power-max?
-    |        |        |     |       power-dbm
-    |        |        |     +--ro rx-channel-power-min?
-    |        |        |     |       power-dbm
-    |        |        |     +--ro rx-channel-power-max?
-    |        |        |     |       power-dbm
-    |        |        |     +--ro rx-total-power-max?
-    |        |        |             power-dbm
+    |        |        |     +--ro operational-mode?          operational-mode
+    |        |        |     +--ro organization-identifier?   organization-identifier
+    |        |        |     +--ro line-coding-bitrate*       identityref
+    |        |        |     +--ro min-central-frequency?     frequency-thz
+    |        |        |     +--ro max-central-frequency?     frequency-thz
+    |        |        |     +--ro transceiver-tunability?    frequency-ghz
+    |        |        |     +--ro tx-channel-power-min?      power-dbm
+    |        |        |     +--ro tx-channel-power-max?      power-dbm
+    |        |        |     +--ro rx-channel-power-min?      power-dbm
+    |        |        |     +--ro rx-channel-power-max?      power-dbm
+    |        |        |     +--ro rx-total-power-max?        power-dbm
     |        |        +--:(explicit-mode)
     |        |           +--ro explicit-mode
-    |        |              +--ro line-coding-bitrate?
-    |        |              |       identityref
-    |        |              +--ro bitrate?
-    |        |              |       uint16
-    |        |              +--ro max-diff-group-delay?
-    |        |              |       uint32
-    |        |              +--ro max-chromatic-dispersion?
-    |        |              |       decimal64
-    |        |              +--ro cd-penalty* []
-    |        |              |  +--ro cd-value         union
-    |        |              |  +--ro penalty-value    union
-    |        |              +--ro max-polarization-mode-dispersion?
-    |        |              |       decimal64
-    |        |              +--ro pmd-penalty* []
-    |        |              |  +--ro pmd-value        union
-    |        |              |  +--ro penalty-value    union
-    |        |              +--ro max-polarization-dependant-loss
-    |        |              |       power-loss-or-null
-    |        |              +--ro pdl-penalty* []
-    |        |              |  +--ro pdl-value
-    |        |              |  |       power-loss-or-null
-    |        |              |  +--ro penalty-value    union
-    |        |              +--ro available-modulation-type?
-    |        |              |       identityref
-    |        |              +--ro min-OSNR?
-    |        |              |       snr
-    |        |              +--ro rx-ref-channel-power?
-    |        |              |       power-dbm
-    |        |              +--ro rx-channel-power-penalty* []
-    |        |              |  +--ro rx-channel-power-value
-    |        |              |  |       power-dbm-or-null
-    |        |              |  +--ro penalty-value             union
-    |        |              +--ro min-Q-factor?
-    |        |              |       int32
-    |        |              +--ro available-baud-rate?
-    |        |              |       uint32
-    |        |              +--ro roll-off?
-    |        |              |       decimal64
-    |        |              +--ro min-carrier-spacing?
-    |        |              |       frequency-ghz
-    |        |              +--ro available-fec-type?
-    |        |              |       identityref
-    |        |              +--ro fec-code-rate?
-    |        |              |       decimal64
-    |        |              +--ro fec-threshold?
-    |        |              |       decimal64
-    |        |              +--ro in-band-osnr?
-    |        |              |       snr
-    |        |              +--ro out-of-band-osnr?
-    |        |              |       snr
-    |        |              +--ro tx-polarization-power-difference?
-    |        |              |       power-ratio
-    |        |              +--ro polarization-skew?
-    |        |              |       decimal64
-    |        |              +--ro min-central-frequency?
-    |        |              |       frequency-thz
-    |        |              +--ro max-central-frequency?
-    |        |              |       frequency-thz
-    |        |              +--ro transceiver-tunability?
-    |        |              |       frequency-ghz
-    |        |              +--ro tx-channel-power-min?
-    |        |              |       power-dbm
-    |        |              +--ro tx-channel-power-max?
-    |        |              |       power-dbm
-    |        |              +--ro rx-channel-power-min?
-    |        |              |       power-dbm
-    |        |              +--ro rx-channel-power-max?
-    |        |              |       power-dbm
-    |        |              +--ro rx-total-power-max?
-    |        |              |       power-dbm
+    |        |              +--ro min-central-frequency?           frequency-thz
+    |        |              +--ro max-central-frequency?           frequency-thz
+    |        |              +--ro transceiver-tunability?          frequency-ghz
+    |        |              +--ro tx-channel-power-min?            power-dbm
+    |        |              +--ro tx-channel-power-max?            power-dbm
+    |        |              +--ro rx-channel-power-min?            power-dbm
+    |        |              +--ro rx-channel-power-max?            power-dbm
+    |        |              +--ro rx-total-power-max?              power-dbm
     |        |              +--ro compatible-modes
-    |        |                 +--ro supported-application-codes*
-    |        |                 |       -> ../../../mode-id
-    |        |                 +--ro supported-organizational-modes*
-    |        |                         -> ../../../mode-id
+    |        |              |  +--ro supported-application-codes*      -> ../../../mode-id
+    |        |              |  +--ro supported-organizational-modes*   -> ../../../mode-id
+    |        |              +--ro explicit-transceiver-mode-ref?   -> ../../../../../../../../templates/explicit-transceiver-modes/explicit-transceiver-mode/explicit-transceiver-mode-id
     |        +--ro configured-mode?               union
     |        +--ro line-coding-bitrate?           identityref
     |        +--ro tx-channel-power?              power-dbm-or-null
     |        +--ro rx-channel-power?              power-dbm-or-null
     |        +--ro rx-total-power?                power-dbm-or-null
     |        +--ro outgoing-otsi
-    |        |  +--ro otsi-group-ref?   leafref
-    |        |  +--ro otsi-ref?         leafref
+    |        |  +--ro otsi-group-ref?   -> ../../../../../../otsis/otsi-group/otsi-group-id
+    |        |  +--ro otsi-ref?         -> ../../../../../../otsis/otsi-group[otsi-group-id=current()/../otsi-group-ref]/otsi/otsi-carrier-id
     |        +--ro incoming-otsi
-    |        |  +--ro otsi-group-ref?   leafref
-    |        |  +--ro otsi-ref?         leafref
+    |        |  +--ro otsi-group-ref?   -> ../../../../../../otsis/otsi-group/otsi-group-id
+    |        |  +--ro otsi-ref?         -> ../../../../../../otsis/otsi-group[otsi-group-id=current()/../otsi-group-ref]/otsi/otsi-carrier-id
     |        +--ro configured-termination-type?   enumeration
     +--rw regen-groups!
        +--ro regen-group* [group-id]
           +--ro group-id           uint32
           +--ro regen-metric?      uint32
-          +--ro transponder-ref*
-                  -> ../../../transponders/transponder/transponder-id
-  augment /nw:networks/nw:network/nt:link/tet:te
-            /tet:te-link-attributes:
+          +--ro transponder-ref*   -> ../../../transponders/transponder/transponder-id
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes:
     +--ro OMS-attributes
        +--ro generalized-snr?        l0-types:snr
        +--ro equalization-mode?      identityref
@@ -169,19 +169,18 @@ module: ietf-optical-impairment-topology
        |     +--ro media-channels* []
        |        +--ro flexi-n?          l0-types:flexi-n
        |        +--ro flexi-m?          l0-types:flexi-m
-       |        +--ro otsi-group-ref?   leafref
+       |        +--ro otsi-group-ref?   -> ../../../../../../../../otsis/otsi-group/otsi-group-id
        |        +--ro otsi-ref* []
-       |        |  +--ro otsi-carrier-ref?   leafref
-       |        |  +--ro e2e-mc-path-ref*    leafref
+       |        |  +--ro otsi-carrier-ref?   -> ../../../../../../../../../otsis/otsi-group[otsi-group-id=current()/../../otsi-group-ref]/otsi/otsi-carrier-id
+       |        |  +--ro e2e-mc-path-ref*    -> ../../../../../../../../../otsis/otsi-group[otsi-group-id=current()/../../otsi-group-ref]/otsi[otsi-carrier-id=current()/../otsi-carrier-ref]/e2e-mc-path-id
        |        +--ro delta-power?      l0-types:power-ratio-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
              +--ro oms-element-uid?          union
              +--ro reverse-element-ref
-             |  +--ro link-ref?
-             |  |       -> ../../../../../../../../nt:link/link-id
-             |  +--ro oms-element-ref*   leafref
+             |  +--ro link-ref?          -> ../../../../../../../../nt:link/link-id
+             |  +--ro oms-element-ref*   -> ../../../../../../../../nt:link[nt:link-id=current()/../link-ref]/tet:te/te-link-attributes/OMS-attributes/OMS-elements/OMS-element/elt-index
              +--ro (element)
                 +--:(amplifier)
                 |  +--ro geolocation
@@ -192,202 +191,90 @@ module: ietf-optical-impairment-topology
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element* []
-                |           +--ro name?
-                |           |       string
-                |           +--ro type-variety?
-                |           |       string
-                |           +--ro is-dynamic-gain-equalyzer?
-                |           |       boolean
+                |           +--ro name?                           string
+                |           +--ro type-variety?                   string
+                |           +--ro is-dynamic-gain-equalyzer?      boolean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
-                |           +--ro stage-order?
-                |           |       uint8
+                |           +--ro stage-order?                    uint8
                 |           +--ro power-param
                 |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
-                |           |     |  +--ro nominal-carrier-power
-                |           |     |          l0-types:power-dbm-or-null
+                |           |     |  +--ro nominal-carrier-power    l0-types:power-dbm-or-null
                 |           |     +--:(power-spectral-density)
-                |           |        +--ro nominal-psd
-                |           |                l0-types:psd-or-null
-                |           +--ro pdl?
-                |           |       l0-types:power-loss-or-null
+                |           |        +--ro nominal-psd              l0-types:psd-or-null
+                |           +--ro pdl?                            l0-types:power-loss-or-null
                 |           +--ro (amplifier-element-type)
                 |              +--:(optical-amplifier)
                 |              |  +--ro optical-amplifier
-                |              |     +--ro actual-gain
-                |              |     |       l0-types:power-gain-or-null
-                |              |     +--ro in-voa?
-                |              |     |       l0-types:power-loss-or-null
-                |              |     +--ro out-voa?
-                |              |     |       l0-types:power-loss-or-null
-                |              |     +--ro tilt-target
-                |              |     |       l0-types:decimal-2-or-null
-                |              |     +--ro total-output-power
-                |              |     |       l0-types:power-dbm-or-null
-                |              |     +--ro raman-direction?
-                |              |     |       enumeration
+                |              |     +--ro actual-gain           l0-types:power-gain-or-null
+                |              |     +--ro in-voa?               l0-types:power-loss-or-null
+                |              |     +--ro out-voa?              l0-types:power-loss-or-null
+                |              |     +--ro tilt-target           l0-types:decimal-2-or-null
+                |              |     +--ro total-output-power    l0-types:power-dbm-or-null
+                |              |     +--ro raman-direction?      enumeration
                 |              |     +--ro raman-pump* []
-                |              |        +--ro frequency?
-                |              |        |       l0-types:frequency-thz
-                |              |        +--ro power?
-                |              |                l0-types:decimal-2-or-null
+                |              |        +--ro frequency?   l0-types:frequency-thz
+                |              |        +--ro power?       l0-types:decimal-2-or-null
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
                 |                    +--ro media-channel-groups
                 |                       +--ro media-channel-group* []
                 |                          +--ro media-channels* []
-                |                             +--ro flexi-n?
-                |                             |       l0-types:flexi-n
-                |                             +--ro flexi-m?
-                |                             |       l0-types:flexi-m
-                |                             +--ro delta-power?
-                |                                     l0-types:power-ratio-or-null
+                |                             +--ro flexi-n?       l0-types:flexi-n
+                |                             +--ro flexi-m?       l0-types:flexi-m
+                |                             +--ro delta-power?   l0-types:power-ratio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string
-                |     +--ro length
-                |     |       l0-types:decimal-2-or-null
-                |     +--ro loss-coef
-                |     |       l0-types:decimal-2-or-null
-                |     +--ro total-loss
-                |     |       l0-types:power-loss-or-null
-                |     +--ro pmd?
-                |     |       l0-types:decimal-2-or-null
-                |     +--ro conn-in?
-                |     |       l0-types:power-loss-or-null
-                |     +--ro conn-out?
-                |             l0-types:power-loss-or-null
+                |     +--ro length          l0-types:decimal-2-or-null
+                |     +--ro loss-coef       l0-types:decimal-2-or-null
+                |     +--ro total-loss      l0-types:power-loss-or-null
+                |     +--ro pmd?            l0-types:decimal-2-or-null
+                |     +--ro conn-in?        l0-types:power-loss-or-null
+                |     +--ro conn-out?       l0-types:power-loss-or-null
                 +--:(concentratedloss)
                    +--ro concentratedloss
                       +--ro loss    l0-types:power-loss-or-null
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:tunnel-termination-point:
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
-       +--ro transponder-ref
-       |       -> ../../../../transponders/transponder/transponder-id
-       +--ro transceiver-ref    leafref
+       +--ro transponder-ref    -> ../../../../transponders/transponder/transponder-id
+       +--ro transceiver-ref    -> ../../../../transponders/transponder[transponder-id=current()/../transponder-ref]/transceiver/transceiver-id
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw protection-type?   identityref
-  augment /nw:networks/nw:network/nw:node/nt:termination-point
-            /tet:te:
+  augment /nw:networks/nw:network/nw:node/nt:termination-point/tet:te:
     +--rw inter-layer-sequence-number?   uint32
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes:
-    +--ro roadm-path-impairments* [roadm-path-impairments-id]
-       +--ro roadm-path-impairments-id    uint32
-       +--ro (impairment-type)?
-          +--:(roadm-express-path)
-          |  +--ro roadm-express-path* []
-          |     +--ro frequency-range
-          |     |  +--ro lower-frequency    frequency-thz
-          |     |  +--ro upper-frequency    frequency-thz
-          |     +--ro roadm-pmd?                union
-          |     +--ro roadm-cd?
-          |     |       l0-types:decimal-5-or-null
-          |     +--ro roadm-pdl?
-          |     |       l0-types:power-loss-or-null
-          |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types:decimal-2-or-null
-          |     +--ro roadm-maxloss?
-          |             l0-types:power-loss-or-null
-          +--:(roadm-add-path)
-          |  +--ro roadm-add-path* []
-          |     +--ro frequency-range
-          |     |  +--ro lower-frequency    frequency-thz
-          |     |  +--ro upper-frequency    frequency-thz
-          |     +--ro roadm-pmd?                union
-          |     +--ro roadm-cd?
-          |     |       l0-types:decimal-5-or-null
-          |     +--ro roadm-pdl?
-          |     |       l0-types:power-loss-or-null
-          |     +--ro roadm-inband-crosstalk?
-          |     |       l0-types:decimal-2-or-null
-          |     +--ro roadm-maxloss?
-          |     |       l0-types:power-loss-or-null
-          |     +--ro roadm-pmax?
-          |     |       l0-types:power-dbm-or-null
-          |     +--ro roadm-osnr?               l0-types:snr-or-null
-          |     +--ro roadm-noise-figure?
-          |             l0-types:decimal-5-or-null
-          +--:(roadm-drop-path)
-             +--ro roadm-drop-path* []
-                +--ro frequency-range
-                |  +--ro lower-frequency    frequency-thz
-                |  +--ro upper-frequency    frequency-thz
-                +--ro roadm-pmd?                union
-                +--ro roadm-cd?
-                |       l0-types:decimal-5-or-null
-                +--ro roadm-pdl?
-                |       l0-types:power-loss-or-null
-                +--ro roadm-inband-crosstalk?
-                |       l0-types:decimal-2-or-null
-                +--ro roadm-maxloss?
-                |       l0-types:power-loss-or-null
-                +--ro roadm-minloss?
-                |       l0-types:power-loss-or-null
-                +--ro roadm-typloss?
-                |       l0-types:power-loss-or-null
-                +--ro roadm-pmin?
-                |       l0-types:power-dbm-or-null
-                +--ro roadm-pmax?
-                |       l0-types:power-dbm-or-null
-                +--ro roadm-ptyp?
-                |       l0-types:power-dbm-or-null
-                +--ro roadm-osnr?               l0-types:snr-or-null
-                +--ro roadm-noise-figure?
-                        l0-types:decimal-5-or-null
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:information-source-entry/tet:connectivity-matrices:
-    +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:information-source-entry/tet:connectivity-matrices
-            /tet:connectivity-matrix:
-    +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes/tet:connectivity-matrices:
-    +--ro roadm-path-impairments?
-            -> ../../roadm-path-impairments/roadm-path-impairments-id
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes/tet:connectivity-matrices
-            /tet:connectivity-matrix:
-    +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes/tet:connectivity-matrices
-            /tet:connectivity-matrix/tet:from:
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes:
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices:
+    +--ro roadm-path-impairments?   -> ../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix:
+    +--ro roadm-path-impairments?   -> ../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices:
+    +--ro roadm-path-impairments?   -> ../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix:
+    +--ro roadm-path-impairments?   -> ../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:from:
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref
-       |       -> ../../../../../../../nt:termination-point/tp-id
-       +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:te-node-attributes/tet:connectivity-matrices
-            /tet:connectivity-matrix/tet:to:
+       +--ro ltp-ref                   -> ../../../../../../../nt:termination-point/tp-id
+       +--ro roadm-path-impairments?   -> ../../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:to:
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref
-       |       -> ../../../../../../../nt:termination-point/tp-id
-       +--ro roadm-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:tunnel-termination-point
-            /tet:local-link-connectivities:
-    +--ro add-path-impairments?    leafref
-    +--ro drop-path-impairments?   leafref
-  augment /nw:networks/nw:network/nw:node/tet:te
-            /tet:tunnel-termination-point
-            /tet:local-link-connectivities
-            /tet:local-link-connectivity:
-    +--ro add-path-impairments?    leafref
-    +--ro drop-path-impairments?   leafref
+       +--ro ltp-ref                   -> ../../../../../../../nt:termination-point/tp-id
+       +--ro roadm-path-impairments?   -> ../../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities:
+    +--ro add-path-impairments?    -> ../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+    +--ro drop-path-impairments?   -> ../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity:
+    +--ro add-path-impairments?    -> ../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+    +--ro drop-path-impairments?   -> ../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
     +--ro llc-transceiver* [ttp-transponder-ref ttp-transceiver-ref]
-    |  +--ro ttp-transponder-ref
-    |  |       -> ../../../../ttp-transceiver/transponder-ref
-    |  +--ro ttp-transceiver-ref
-    |  |       -> ../../../../ttp-transceiver/transceiver-ref
+    |  +--ro ttp-transponder-ref      -> ../../../../ttp-transceiver/transponder-ref
+    |  +--ro ttp-transceiver-ref      -> ../../../../ttp-transceiver/transceiver-ref
     |  +--ro is-allowed?              boolean
-    |  +--ro add-path-impairments?    leafref
-    |  +--ro drop-path-impairments?   leafref
+    |  +--ro add-path-impairments?    -> ../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+    |  +--ro drop-path-impairments?   -> ../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
     +--ro additional-ltp* [ltp-ref]
-       +--ro ltp-ref
-       |       -> ../../../../../../nt:termination-point/tp-id
-       +--ro add-path-impairments?    leafref
-       +--ro drop-path-impairments?   leafref
+       +--ro ltp-ref                  -> ../../../../../../nt:termination-point/tp-id
+       +--ro add-path-impairments?    -> ../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id
+       +--ro drop-path-impairments?   -> ../../../../../../../templates/roadm-path-impairments/roadm-path-impairment/roadm-path-impairments-id

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -1043,7 +1043,7 @@ module ietf-optical-impairment-topology {
               When not present, the configured-mode is not reported 
               by the server.";
           }
-          uses l0-types:common-transceiver-configured-param;
+          uses l0-types:common-transceiver-param;
           container outgoing-otsi {
             when "../../../../../otsis" {
               description

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -1,9 +1,7 @@
 module ietf-optical-impairment-topology {
   yang-version 1.1;
-
   namespace "urn:ietf:params:xml"
           + ":ns:yang:ietf-optical-impairment-topology";
-
   prefix "oit";
 
   import ietf-network {
@@ -87,7 +85,7 @@ module ietf-optical-impairment-topology {
 // this note
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2024-01-23 {
+  revision 2024-02-14 {
     description
       "Initial Version";
     reference
@@ -947,7 +945,102 @@ module ietf-optical-impairment-topology {
         uses otsi-group;
       } // list of OTSiG
     }
-  }
+
+    container templates {
+      config false;
+      description
+        "Templates for set of parameters which can be common to
+        multiple elements.";
+      container roadm-path-impairments {
+        description
+          "The top level container for the list of the set of
+          optical impairments related to ROADM paths.";
+        list roadm-path-impairment {
+          key "roadm-path-impairments-id";
+          description
+            "The list of the set of optical impairments related to
+            ROADM paths.";
+
+          leaf roadm-path-impairments-id {
+            type string; 
+            description
+              "The identifier of the set of optical impairments
+              related to a ROADM path.";
+          }
+          choice impairment-type {
+            description "type path impairment";
+            case roadm-express-path {
+              list roadm-express-path {
+                description
+                  "The list of optical impairments on a ROADM express
+                  path for different frequency ranges.
+                  
+                  Two elements in the list must not have the same
+                  range or overlapping ranges.";
+                container frequency-range {
+                  description
+                    "The frequency range for which these optical
+                    impairments apply.";
+                  uses l0-types:frequency-range;
+                }
+                uses roadm-express-path;
+              } 
+            }
+            case roadm-add-path {
+              list roadm-add-path {
+                description
+                  "The list of optical impairments on a ROADM add
+                  path for different frequency ranges.
+                  
+                  Two elements in the list must not have the same
+                  range or overlapping ranges.";
+                container frequency-range {
+                  description
+                    "The frequency range for which these optical
+                    impairments apply.";
+                  uses l0-types:frequency-range;
+                }
+                uses roadm-add-path; 
+              }
+            }          
+            case roadm-drop-path {
+              list roadm-drop-path {
+                description
+                  "The list of optical impairments on a ROADM add
+                  path for different frequency ranges.
+                  
+                  Two elements in the list must not have the same
+                  range or overlapping ranges.";
+                container frequency-range {
+                  description
+                    "The frequency range for which these optical
+                    impairments apply.";
+                  uses l0-types:frequency-range;
+                }
+                uses roadm-drop-path; 
+              }
+            }
+          }
+        } // list roadm-path-impairments 
+      } // container roadm-path-impairments 
+      container explicit-transceiver-modes {
+        description
+          "The top level container for the list of the
+          transceivers' explicit modes.";
+        list explicit-transceiver-mode {
+          key explicit-transceiver-mode-id;
+          description
+            "The list of the transceivers' explicit modes.";
+          leaf explicit-transceiver-mode-id {
+            type string;
+            description
+              "The identifier of the transceivers' explicit mode.";
+          }
+          uses l0-types:explicit-mode;
+        }   // list explicit-transceiver-mode
+      }   // container explicit-transceiver-modes
+    }   // container templates
+  } // augment network
 
   augment "/nw:networks/nw:network/nw:node" {
     when "../nw:network-types/tet:te-topology" +
@@ -1025,7 +1118,25 @@ module ietf-optical-impairment-topology {
             type uint32;
             description "transceiver identifier";
           }
-          uses l0-types:transceiver-capabilities;
+          uses l0-types:transceiver-capabilities {
+            augment "supported-modes/supported-mode/mode/"
+                  + "explicit-mode/explicit-mode" {
+              description
+                "Augment the explicit-mode container with the
+                proper leafref.";
+              leaf explicit-transceiver-mode-ref {
+                type leafref {
+                  path "../../../../../../../../oit:templates"
+                      + "/oit:explicit-transceiver-modes"
+                      + "/oit:explicit-transceiver-mode"
+                      + "/oit:explicit-transceiver-mode-id";
+                }
+                description
+                  "The refernce to the explicit transceiver
+                  mode template.";
+              }
+            }
+          }
           leaf configured-mode {
             type union {
               type empty;
@@ -1259,71 +1370,6 @@ module ietf-optical-impairment-topology {
       "node attributes augmentantion for optical-impairment ROADM
        node";
 
-    list roadm-path-impairments {
-      key "roadm-path-impairments-id";
-      config false;
-      description
-        "The set of optical impairments related to a ROADM path.";
-
-      leaf roadm-path-impairments-id {
-        type uint32; 
-        description "index of the ROADM path-impairment list";
-      }
-      choice impairment-type {
-        description "type path impairment";
-        case roadm-express-path {
-          list roadm-express-path {
-            description
-              "The list of optical impairments on a ROADM express
-              path for different frequency ranges.
-              
-              Two elements in the list must not have the same range
-              or overlapping ranges.";
-            container frequency-range {
-              description
-                "The frequency range for which these optical
-                impairments apply.";
-              uses l0-types:frequency-range;
-            }
-            uses roadm-express-path;
-          } 
-        }
-        case roadm-add-path {
-          list roadm-add-path {
-            description
-              "The list of optical impairments on a ROADM add
-              path for different frequency ranges.
-              
-              Two elements in the list must not have the same range
-              or overlapping ranges.";
-            container frequency-range {
-              description
-                "The frequency range for which these optical
-                impairments apply.";
-              uses l0-types:frequency-range;
-            }
-            uses roadm-add-path; 
-          }
-        }          
-        case roadm-drop-path {
-          list roadm-drop-path {
-            description
-              "The list of optical impairments on a ROADM add
-              path for different frequency ranges.
-              
-              Two elements in the list must not have the same range
-              or overlapping ranges.";
-            container frequency-range {
-              description
-                "The frequency range for which these optical
-                impairments apply.";
-              uses l0-types:frequency-range;
-            }
-            uses roadm-drop-path; 
-          }
-        }
-      }
-    } // list path impairments 
   } // augmentation for optical-impairment ROADM 
 
   augment "/nw:networks/nw:network/nw:node/tet:te/"
@@ -1340,8 +1386,9 @@ module ietf-optical-impairment-topology {
 
     leaf roadm-path-impairments {
       type leafref {
-        path "../../../tet:te-node-attributes/"
-           + "roadm-path-impairments/roadm-path-impairments-id";
+        path "../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id";
       }
       config false;
       description
@@ -1363,8 +1410,9 @@ module ietf-optical-impairment-topology {
       source.";
     leaf roadm-path-impairments {
       type leafref {
-        path "../../../../tet:te-node-attributes/"
-           + "roadm-path-impairments/roadm-path-impairments-id";
+        path "../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id";
       }
       config false;
       description
@@ -1384,8 +1432,9 @@ module ietf-optical-impairment-topology {
       "Augment default TE node connectivity matrix.";
     leaf roadm-path-impairments {
       type leafref {
-        path "../../roadm-path-impairments/"
-        + "roadm-path-impairments-id";
+        path "../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id";
       }
       config false; /*the identifier in the list */
        /*"roadm-path-impairments" of ROADM optical impairment*/
@@ -1408,8 +1457,9 @@ module ietf-optical-impairment-topology {
       "Augment TE node connectivity matrix entry.";
     leaf roadm-path-impairments {
       type leafref {
-        path "../../../roadm-path-impairments/"
-        + "roadm-path-impairments-id";
+        path "../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id";
       }
       config false;
       description "pointer to the list set of ROADM optical
@@ -1461,8 +1511,9 @@ module ietf-optical-impairment-topology {
       }
       leaf roadm-path-impairments {
         type leafref {
-          path "../../../../../../../tet:te/tet:te-node-attributes/"
-             + "roadm-path-impairments/roadm-path-impairments-id";
+          path "../../../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id";
         }
         description
           "Pointer to ROADM optical impairments of the ROADM path 
@@ -1516,8 +1567,9 @@ module ietf-optical-impairment-topology {
       }
       leaf roadm-path-impairments {
         type leafref {
-          path "../../../../../../../tet:te/tet:te-node-attributes/"
-             + "roadm-path-impairments/roadm-path-impairments-id";
+          path "../../../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id";
         }
         description
           "Pointer to ROADM optical impairments of the ROADM path 
@@ -1539,8 +1591,9 @@ module ietf-optical-impairment-topology {
       "Augment default TTP LLC.";
     leaf add-path-impairments {
       type leafref {
-        path "../../../tet:te-node-attributes/"
-        + "roadm-path-impairments/roadm-path-impairments-id" ;
+        path "../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id" ;
       }
       config false;
       description "pointer to the list set of ROADM optical
@@ -1548,8 +1601,9 @@ module ietf-optical-impairment-topology {
     }
     leaf drop-path-impairments {
       type leafref {
-        path "../../../tet:te-node-attributes/"
-        + "roadm-path-impairments/roadm-path-impairments-id" ;
+        path "../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id" ;
       }
       config false;
       description "pointer to the list set of ROADM 
@@ -1571,8 +1625,9 @@ module ietf-optical-impairment-topology {
       "Augment TTP LLC entry.";
     leaf add-path-impairments {
       type leafref {
-        path "../../../../tet:te-node-attributes/"
-        + "roadm-path-impairments/roadm-path-impairments-id" ;
+        path "../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id" ;
       }
       config false;
       description "pointer to the list set of ROADM optical
@@ -1580,8 +1635,9 @@ module ietf-optical-impairment-topology {
     }
     leaf drop-path-impairments {
       type leafref {
-        path "../../../../tet:te-node-attributes/"
-        + "roadm-path-impairments/roadm-path-impairments-id" ;
+        path "../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id" ;
       }
       config false;
       description "pointer to the list set of ROADM optical 
@@ -1617,16 +1673,18 @@ module ietf-optical-impairment-topology {
       }
       leaf add-path-impairments {
         type leafref {
-          path "../../../../../tet:te-node-attributes/"
-          + "roadm-path-impairments/roadm-path-impairments-id" ;
+          path "../../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id" ;
         }
         description "pointer to the list set of ROADM optical
         impairments";
       }
       leaf drop-path-impairments {
         type leafref {
-          path "../../../../../tet:te-node-attributes/"
-          + "roadm-path-impairments/roadm-path-impairments-id" ;
+          path "../../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id" ;
         }
         description "pointer to the list set of ROADM 
         optical impairments";
@@ -1659,16 +1717,18 @@ module ietf-optical-impairment-topology {
       }
       leaf add-path-impairments {
         type leafref {
-          path "../../../../../tet:te-node-attributes/"
-          + "roadm-path-impairments/roadm-path-impairments-id" ;
+          path "../../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id" ;
         }
         description "pointer to the list set of ROADM optical
         impairments";
       }
       leaf drop-path-impairments {
         type leafref {
-          path "../../../../../tet:te-node-attributes/"
-          + "roadm-path-impairments/roadm-path-impairments-id" ;
+          path "../../../../../../../oit:templates"
+           + "/oit:roadm-path-impairments/oit:roadm-path-impairment"
+           + "/oit:roadm-path-impairments-id" ;
         }
         description "pointer to the list set of ROADM 
         optical impairments";


### PR DESCRIPTION
Further updates for WG LC preparation:
- Update grouping name for common transceiver parameters
- Addressed issue #164 

---

Pending merge of https://github.com/ietf-ccamp-wg/ietf-ccamp-layer0-types-ext-RFC9093-bis/pull/93

---

Co-authored-by: sergio belotti <sergio.belotti@nokia.com>
Co-authored-by: agva123 <agva123@gmail.com>