### PR TITLE
YANG updates for the -16 version of the I-D

### DIFF
--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -311,7 +311,7 @@ r-null
                 |                    +--ro media-channel* [flexi-n]
                 |                       +--ro flexi-n
                 |                       |       l0-types:flexi-n
-                |                       +--ro flexi-m?
+                |                       +--ro flexi-m
                 |                       |       l0-types:flexi-m
                 |                       +--ro delta-power?
                 |                               l0-types:power-ratio\

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -90,27 +90,23 @@ module: ietf-optical-impairment-topology
              +--ro bitrate?                            uint16
              +--ro max-diff-group-delay?               decimal-2
              +--ro max-chromatic-dispersion?           decimal-2
-             +--ro cd-penalty* [cd-index]
-             |  +--ro cd-index         decimal-2
-             |  +--ro cd-value         union
+             +--ro cd-penalty* [cd-value]
+             |  +--ro cd-value         decimal-2
              |  +--ro penalty-value    union
              +--ro max-polarization-mode-dispersion?   decimal-2
-             +--ro pmd-penalty* [pmd-index]
-             |  +--ro pmd-index        decimal-2
-             |  +--ro pmd-value        union
+             +--ro pmd-penalty* [pmd-value]
+             |  +--ro pmd-value        decimal-2
              |  +--ro penalty-value    union
              +--ro max-polarization-dependant-loss
              |       power-loss-or-null
-             +--ro pdl-penalty* [pdl-index]
-             |  +--ro pdl-index        decimal-2
-             |  +--ro pdl-value        power-loss-or-null
+             +--ro pdl-penalty* [pdl-value]
+             |  +--ro pdl-value        power-loss
              |  +--ro penalty-value    union
              +--ro available-modulation-type?          identityref
              +--ro min-OSNR?                           snr
              +--ro rx-ref-channel-power?               power-dbm
-             +--ro rx-channel-power-penalty* [rx-channel-power-index]
-             |  +--ro rx-channel-power-index    decimal-2
-             |  +--ro rx-channel-power-value    power-dbm-or-null
+             +--ro rx-channel-power-penalty* [rx-channel-power-value]
+             |  +--ro rx-channel-power-value    power-dbm
              |  +--ro penalty-value             union
              +--ro min-Q-factor?                       decimal-2
              +--ro available-baud-rate?                decimal64

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -302,8 +302,8 @@ hz
                 |              |        +--ro power?
                 |              |                l0-types:decimal-2-o\
 r-null
-                |              +--:(dynamic-gain-equalyzer)
-                |                 +--ro dynamic-gain-equalyzer!
+                |              +--:(dynamic-gain-equalizer)
+                |                 +--ro dynamic-gain-equalizer!
                 |                    +--ro media-channel* [flexi-n]
                 |                       +--ro flexi-n
                 |                       |       l0-types:flexi-n

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -18,7 +18,8 @@ module: ietf-optical-impairment-topology
        |     +--ro roadm-path-impairments-id    string
        |     +--ro (impairment-type)?
        |        +--:(roadm-express-path)
-       |        |  +--ro roadm-express-path* []
+       |        |  +--ro roadm-express-path* [frequency-range-id]
+       |        |     +--ro frequency-range-id        uint16
        |        |     +--ro frequency-range
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
@@ -32,7 +33,8 @@ module: ietf-optical-impairment-topology
        |        |     +--ro roadm-maxloss?
        |        |             l0-types:power-loss-or-null
        |        +--:(roadm-add-path)
-       |        |  +--ro roadm-add-path* []
+       |        |  +--ro roadm-add-path* [frequency-range-id]
+       |        |     +--ro frequency-range-id        uint16
        |        |     +--ro frequency-range
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
@@ -52,7 +54,8 @@ module: ietf-optical-impairment-topology
        |        |     +--ro roadm-noise-figure?
        |        |             l0-types:decimal-5-or-null
        |        +--:(roadm-drop-path)
-       |           +--ro roadm-drop-path* []
+       |           +--ro roadm-drop-path* [frequency-range-id]
+       |              +--ro frequency-range-id        uint16
        |              +--ro frequency-range
        |              |  +--ro lower-frequency    frequency-thz
        |              |  +--ro upper-frequency    frequency-thz
@@ -86,23 +89,27 @@ module: ietf-optical-impairment-topology
              +--ro line-coding-bitrate?                identityref
              +--ro bitrate?                            uint16
              +--ro max-diff-group-delay?               decimal-2
-             +--ro max-chromatic-dispersion?           decimal64
-             +--ro cd-penalty* []
+             +--ro max-chromatic-dispersion?           decimal-2
+             +--ro cd-penalty* [cd-index]
+             |  +--ro cd-index         decimal-2
              |  +--ro cd-value         union
              |  +--ro penalty-value    union
-             +--ro max-polarization-mode-dispersion?   decimal64
-             +--ro pmd-penalty* []
+             +--ro max-polarization-mode-dispersion?   decimal-2
+             +--ro pmd-penalty* [pmd-index]
+             |  +--ro pmd-index        decimal-2
              |  +--ro pmd-value        union
              |  +--ro penalty-value    union
              +--ro max-polarization-dependant-loss
              |       power-loss-or-null
-             +--ro pdl-penalty* []
+             +--ro pdl-penalty* [pdl-index]
+             |  +--ro pdl-index        decimal-2
              |  +--ro pdl-value        power-loss-or-null
              |  +--ro penalty-value    union
              +--ro available-modulation-type?          identityref
              +--ro min-OSNR?                           snr
              +--ro rx-ref-channel-power?               power-dbm
-             +--ro rx-channel-power-penalty* []
+             +--ro rx-channel-power-penalty* [rx-channel-power-index]
+             |  +--ro rx-channel-power-index    decimal-2
              |  +--ro rx-channel-power-value    power-dbm-or-null
              |  +--ro penalty-value             union
              +--ro min-Q-factor?                       decimal-2
@@ -115,7 +122,7 @@ module: ietf-optical-impairment-topology
              +--ro in-band-osnr?                       snr
              +--ro out-of-band-osnr?                   snr
              +--ro tx-polarization-power-difference?   power-ratio
-             +--ro polarization-skew?                  decimal64
+             +--ro polarization-skew?                  decimal-2
   augment /nw:networks/nw:network/nw:node:
     +--rw transponders!
     |  +--ro transponder* [transponder-id]
@@ -209,8 +216,7 @@ module: ietf-optical-impairment-topology
           +--ro group-id           uint32
           +--ro regen-metric?      uint32
           +--ro transponder-ref*
-                  -> ../../../transponders/transponder/transponder-i\
-d
+                  -> ../../../transponders/transponder/transponder-id
   augment /nw:networks/nw:network/nt:link/tet:te
             /tet:te-link-attributes:
     +--ro OMS-attributes
@@ -220,15 +226,17 @@ d
        |  +--ro nominal-carrier-power?   l0-types:power-dbm-or-null
        |  +--ro nominal-psd?             l0-types:psd-or-null
        +--ro media-channel-groups!
-       |  +--ro media-channel-group* []
-       |     +--ro media-channels* []
-       |        +--ro flexi-n?          l0-types:flexi-n
-       |        +--ro flexi-m?          l0-types:flexi-m
-       |        +--ro otsi-group-ref?   leafref
-       |        +--ro otsi-ref* []
-       |        |  +--ro otsi-carrier-ref?   leafref
+       |  +--ro media-channel-group* [otsi-group-ref]
+       |     +--ro otsi-group-ref    leafref
+       |     +--ro media-channels* [media-channel-id]
+       |        +--ro media-channel-id    int16
+       |        +--ro flexi-n?            l0-types:flexi-n
+       |        +--ro flexi-m?            l0-types:flexi-m
+       |        +--ro otsi-ref* [otsi-carrier-ref]
+       |        |  +--ro otsi-carrier-ref    leafref
        |        |  +--ro e2e-mc-path-ref*    leafref
-       |        +--ro delta-power?      l0-types:power-ratio-or-null
+       |        +--ro delta-power?
+       |                l0-types:power-ratio-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
@@ -241,14 +249,17 @@ d
                 +--:(amplifier)
                 |  +--ro geolocation
                 |  |  +--ro altitude?    int64
-                |  |  +--ro latitude?    geographic-coordinate-degre\
-e
-                |  |  +--ro longitude?   geographic-coordinate-degre\
-e
+                |  |  +--ro latitude?    geographic-coordinate-degree
+                |  |  +--ro longitude?   geographic-coordinate-degree
                 |  +--ro amplifier
                 |     +--ro type-variety    string
                 |     +--ro operational
-                |        +--ro amplifier-element* []
+                |        +--ro amplifier-element*
+                |                [frequency-range-id stage-order]
+                |           +--ro frequency-range-id
+                |           |       uint16
+                |           +--ro stage-order
+                |           |       uint8
                 |           +--ro name?
                 |           |       string
                 |           +--ro type-variety?
@@ -256,12 +267,8 @@ e
                 |           +--ro is-dynamic-gain-equalyzer?
                 |           |       boolean
                 |           +--ro frequency-range
-                |           |  +--ro lower-frequency    frequency-th\
-z
-                |           |  +--ro upper-frequency    frequency-th\
-z
-                |           +--ro stage-order?
-                |           |       uint8
+                |           |  +--ro lower-frequency    frequency-thz
+                |           |  +--ro upper-frequency    frequency-thz
                 |           +--ro power-param
                 |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
@@ -293,7 +300,8 @@ ull
 ull
                 |              |     +--ro raman-direction?
                 |              |     |       enumeration
-                |              |     +--ro raman-pump* []
+                |              |     +--ro raman-pump* [pump-id]
+                |              |        +--ro pump-id      uint16
                 |              |        +--ro frequency?
                 |              |        |       l0-types:frequency-t\
 hz
@@ -303,10 +311,13 @@ r-null
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
                 |                    +--ro media-channel-groups
-                |                       +--ro media-channel-group* [\
-]
-                |                          +--ro media-channels* []
-                |                             +--ro flexi-n?
+                |                       +--ro media-channel-group*
+                |                               [otsi-group-ref]
+                |                          +--ro otsi-group-ref
+                |                          |       leafref
+                |                          +--ro media-channels*
+                |                                  [flexi-n]
+                |                             +--ro flexi-n
                 |                             |       l0-types:flexi\
 -n
                 |                             +--ro flexi-m?
@@ -322,7 +333,7 @@ r-null
                 |     |       l0-types:decimal-2-or-null
                 |     +--ro loss-coef
                 |     |       l0-types:decimal-2-or-null
-                |     +--ro total-loss
+                |     +--ro total-loss?
                 |     |       l0-types:power-loss-or-null
                 |     +--ro pmd?
                 |     |       l0-types:decimal-2-or-null
@@ -337,8 +348,7 @@ r-null
             /tet:tunnel-termination-point:
     +--ro ttp-transceiver* [transponder-ref transceiver-ref]
        +--ro transponder-ref
-       |       -> ../../../../transponders/transponder/transponder-i\
-d
+       |       -> ../../../../transponders/transponder/transponder-id
        +--ro transceiver-ref    leafref
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw protection-type?   identityref

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -228,7 +228,7 @@ module: ietf-optical-impairment-topology
        +--ro media-channel-groups!
        |  +--ro media-channel-group* [otsi-group-ref]
        |     +--ro otsi-group-ref    leafref
-       |     +--ro media-channels* [media-channel-id]
+       |     +--ro media-channel* [media-channel-id]
        |        +--ro media-channel-id    int16
        |        +--ro flexi-n?            l0-types:flexi-n
        |        +--ro flexi-m?            l0-types:flexi-m
@@ -310,22 +310,16 @@ hz
 r-null
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
-                |                    +--ro media-channel-groups
-                |                       +--ro media-channel-group*
-                |                               [otsi-group-ref]
-                |                          +--ro otsi-group-ref
-                |                          |       leafref
-                |                          +--ro media-channels*
-                |                                  [flexi-n]
-                |                             +--ro flexi-n
-                |                             |       l0-types:flexi\
--n
-                |                             +--ro flexi-m?
-                |                             |       l0-types:flexi\
--m
-                |                             +--ro delta-power?
-                |                                     l0-types:power\
--ratio-or-null
+                |                    +--ro media-channels
+                |                       +--ro media-channel*
+                |                               [flexi-n]
+                |                          +--ro flexi-n
+                |                          |       l0-types:flexi-n
+                |                          +--ro flexi-m?
+                |                          |       l0-types:flexi-m
+                |                          +--ro delta-power?
+                |                                  l0-types:power-ra\
+tio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -264,8 +264,6 @@ module: ietf-optical-impairment-topology
                 |           |       string
                 |           +--ro type-variety?
                 |           |       string
-                |           +--ro is-dynamic-gain-equalyzer?
-                |           |       boolean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz

--- a/ietf-optical-impairment-topology-tree.txt
+++ b/ietf-optical-impairment-topology-tree.txt
@@ -310,16 +310,14 @@ hz
 r-null
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
-                |                    +--ro media-channels
-                |                       +--ro media-channel*
-                |                               [flexi-n]
-                |                          +--ro flexi-n
-                |                          |       l0-types:flexi-n
-                |                          +--ro flexi-m?
-                |                          |       l0-types:flexi-m
-                |                          +--ro delta-power?
-                |                                  l0-types:power-ra\
-tio-or-null
+                |                    +--ro media-channel* [flexi-n]
+                |                       +--ro flexi-n
+                |                       |       l0-types:flexi-n
+                |                       +--ro flexi-m?
+                |                       |       l0-types:flexi-m
+                |                       +--ro delta-power?
+                |                               l0-types:power-ratio\
+-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -16,7 +16,8 @@ module: ietf-optical-impairment-topology
        |     +--ro roadm-path-impairments-id    string
        |     +--ro (impairment-type)?
        |        +--:(roadm-express-path)
-       |        |  +--ro roadm-express-path* []
+       |        |  +--ro roadm-express-path* [express-path-id]
+       |        |     +--ro express-path-id           uint16
        |        |     +--ro frequency-range
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
@@ -30,7 +31,8 @@ module: ietf-optical-impairment-topology
        |        |     +--ro roadm-maxloss?
        |        |             l0-types:power-loss-or-null
        |        +--:(roadm-add-path)
-       |        |  +--ro roadm-add-path* []
+       |        |  +--ro roadm-add-path* [add-path-id]
+       |        |     +--ro add-path-id               uint16
        |        |     +--ro frequency-range
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
@@ -50,7 +52,8 @@ module: ietf-optical-impairment-topology
        |        |     +--ro roadm-noise-figure?
        |        |             l0-types:decimal-5-or-null
        |        +--:(roadm-drop-path)
-       |           +--ro roadm-drop-path* []
+       |           +--ro roadm-drop-path* [drop-path-id]
+       |              +--ro drop-path-id              uint16
        |              +--ro frequency-range
        |              |  +--ro lower-frequency    frequency-thz
        |              |  +--ro upper-frequency    frequency-thz
@@ -217,15 +220,17 @@ module: ietf-optical-impairment-topology
        |  +--ro nominal-carrier-power?   l0-types:power-dbm-or-null
        |  +--ro nominal-psd?             l0-types:psd-or-null
        +--ro media-channel-groups!
-       |  +--ro media-channel-group* []
-       |     +--ro media-channels* []
-       |        +--ro flexi-n?          l0-types:flexi-n
-       |        +--ro flexi-m?          l0-types:flexi-m
-       |        +--ro otsi-group-ref?   leafref
-       |        +--ro otsi-ref* []
-       |        |  +--ro otsi-carrier-ref?   leafref
+       |  +--ro media-channel-group* [otsi-group-ref]
+       |     +--ro otsi-group-ref    leafref
+       |     +--ro media-channels* [media-channel-id]
+       |        +--ro media-channel-id    int16
+       |        +--ro flexi-n?            l0-types:flexi-n
+       |        +--ro flexi-m?            l0-types:flexi-m
+       |        +--ro otsi-ref* [otsi-carrier-ref]
+       |        |  +--ro otsi-carrier-ref    leafref
        |        |  +--ro e2e-mc-path-ref*    leafref
-       |        +--ro delta-power?      l0-types:power-ratio-or-null
+       |        +--ro delta-power?
+       |                l0-types:power-ratio-or-null
        +--ro OMS-elements!
           +--ro OMS-element* [elt-index]
              +--ro elt-index                 uint16
@@ -243,7 +248,12 @@ module: ietf-optical-impairment-topology
                 |  +--ro amplifier
                 |     +--ro type-variety    string
                 |     +--ro operational
-                |        +--ro amplifier-element* []
+                |        +--ro amplifier-element*
+                |                [amplifier-path-id stage-order]
+                |           +--ro amplifier-path-id
+                |           |       uint16
+                |           +--ro stage-order
+                |           |       uint8
                 |           +--ro name?
                 |           |       string
                 |           +--ro type-variety?
@@ -253,8 +263,6 @@ module: ietf-optical-impairment-topology
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz
-                |           +--ro stage-order?
-                |           |       uint8
                 |           +--ro power-param
                 |           |  +--ro (power-param)
                 |           |     +--:(channel-power)
@@ -280,7 +288,8 @@ module: ietf-optical-impairment-topology
                 |              |     |       l0-types:power-dbm-or-null
                 |              |     +--ro raman-direction?
                 |              |     |       enumeration
-                |              |     +--ro raman-pump* []
+                |              |     +--ro raman-pump* [pump-id]
+                |              |        +--ro pump-id      uint16
                 |              |        +--ro frequency?
                 |              |        |       l0-types:frequency-thz
                 |              |        +--ro power?
@@ -288,9 +297,13 @@ module: ietf-optical-impairment-topology
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
                 |                    +--ro media-channel-groups
-                |                       +--ro media-channel-group* []
-                |                          +--ro media-channels* []
-                |                             +--ro flexi-n?
+                |                       +--ro media-channel-group*
+                |                               [otsi-group-ref]
+                |                          +--ro otsi-group-ref
+                |                          |       leafref
+                |                          +--ro media-channels*
+                |                                  [flexi-n]
+                |                             +--ro flexi-n
                 |                             |       l0-types:flexi-n
                 |                             +--ro flexi-m?
                 |                             |       l0-types:flexi-m

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -292,8 +292,8 @@ module: ietf-optical-impairment-topology
                 |              |        |       l0-types:frequency-thz
                 |              |        +--ro power?
                 |              |                l0-types:decimal-2-or-null
-                |              +--:(dynamic-gain-equalyzer)
-                |                 +--ro dynamic-gain-equalyzer!
+                |              +--:(dynamic-gain-equalizer)
+                |                 +--ro dynamic-gain-equalizer!
                 |                    +--ro media-channel* [flexi-n]
                 |                       +--ro flexi-n
                 |                       |       l0-types:flexi-n

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -303,7 +303,7 @@ module: ietf-optical-impairment-topology
                 |     |       l0-types:decimal-2-or-null
                 |     +--ro loss-coef
                 |     |       l0-types:decimal-2-or-null
-                |     +--ro total-loss
+                |     +--ro total-loss?
                 |     |       l0-types:power-loss-or-null
                 |     +--ro pmd?
                 |     |       l0-types:decimal-2-or-null

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -262,8 +262,6 @@ module: ietf-optical-impairment-topology
                 |           |       string
                 |           +--ro type-variety?
                 |           |       string
-                |           +--ro is-dynamic-gain-equalyzer?
-                |           |       boolean
                 |           +--ro frequency-range
                 |           |  +--ro lower-frequency    frequency-thz
                 |           |  +--ro upper-frequency    frequency-thz

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -301,7 +301,7 @@ module: ietf-optical-impairment-topology
                 |                    +--ro media-channel* [flexi-n]
                 |                       +--ro flexi-n
                 |                       |       l0-types:flexi-n
-                |                       +--ro flexi-m?
+                |                       +--ro flexi-m
                 |                       |       l0-types:flexi-m
                 |                       +--ro delta-power?
                 |                               l0-types:power-ratio-or-null

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -226,7 +226,7 @@ module: ietf-optical-impairment-topology
        +--ro media-channel-groups!
        |  +--ro media-channel-group* [otsi-group-ref]
        |     +--ro otsi-group-ref    leafref
-       |     +--ro media-channels* [media-channel-id]
+       |     +--ro media-channel* [media-channel-id]
        |        +--ro media-channel-id    int16
        |        +--ro flexi-n?            l0-types:flexi-n
        |        +--ro flexi-m?            l0-types:flexi-m
@@ -300,19 +300,15 @@ module: ietf-optical-impairment-topology
                 |              |                l0-types:decimal-2-or-null
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
-                |                    +--ro media-channel-groups
-                |                       +--ro media-channel-group*
-                |                               [otsi-group-ref]
-                |                          +--ro otsi-group-ref
-                |                          |       leafref
-                |                          +--ro media-channels*
-                |                                  [flexi-n]
-                |                             +--ro flexi-n
-                |                             |       l0-types:flexi-n
-                |                             +--ro flexi-m?
-                |                             |       l0-types:flexi-m
-                |                             +--ro delta-power?
-                |                                     l0-types:power-ratio-or-null
+                |                    +--ro media-channels
+                |                       +--ro media-channel*
+                |                               [flexi-n]
+                |                          +--ro flexi-n
+                |                          |       l0-types:flexi-n
+                |                          +--ro flexi-m?
+                |                          |       l0-types:flexi-m
+                |                          +--ro delta-power?
+                |                                  l0-types:power-ratio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -88,27 +88,23 @@ module: ietf-optical-impairment-topology
              +--ro bitrate?                            uint16
              +--ro max-diff-group-delay?               decimal-2
              +--ro max-chromatic-dispersion?           decimal-2
-             +--ro cd-penalty* [cd-index]
-             |  +--ro cd-index         decimal-2
-             |  +--ro cd-value         union
+             +--ro cd-penalty* [cd-value]
+             |  +--ro cd-value         decimal-2
              |  +--ro penalty-value    union
              +--ro max-polarization-mode-dispersion?   decimal-2
-             +--ro pmd-penalty* [pmd-index]
-             |  +--ro pmd-index        decimal-2
-             |  +--ro pmd-value        union
+             +--ro pmd-penalty* [pmd-value]
+             |  +--ro pmd-value        decimal-2
              |  +--ro penalty-value    union
              +--ro max-polarization-dependant-loss
              |       power-loss-or-null
-             +--ro pdl-penalty* [pdl-index]
-             |  +--ro pdl-index        decimal-2
-             |  +--ro pdl-value        power-loss-or-null
+             +--ro pdl-penalty* [pdl-value]
+             |  +--ro pdl-value        power-loss
              |  +--ro penalty-value    union
              +--ro available-modulation-type?          identityref
              +--ro min-OSNR?                           snr
              +--ro rx-ref-channel-power?               power-dbm
-             +--ro rx-channel-power-penalty* [rx-channel-power-index]
-             |  +--ro rx-channel-power-index    decimal-2
-             |  +--ro rx-channel-power-value    power-dbm-or-null
+             +--ro rx-channel-power-penalty* [rx-channel-power-value]
+             |  +--ro rx-channel-power-value    power-dbm
              |  +--ro penalty-value             union
              +--ro min-Q-factor?                       decimal-2
              +--ro available-baud-rate?                decimal64

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -16,8 +16,8 @@ module: ietf-optical-impairment-topology
        |     +--ro roadm-path-impairments-id    string
        |     +--ro (impairment-type)?
        |        +--:(roadm-express-path)
-       |        |  +--ro roadm-express-path* [express-path-id]
-       |        |     +--ro express-path-id           uint16
+       |        |  +--ro roadm-express-path* [frequency-range-id]
+       |        |     +--ro frequency-range-id        uint16
        |        |     +--ro frequency-range
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
@@ -31,8 +31,8 @@ module: ietf-optical-impairment-topology
        |        |     +--ro roadm-maxloss?
        |        |             l0-types:power-loss-or-null
        |        +--:(roadm-add-path)
-       |        |  +--ro roadm-add-path* [add-path-id]
-       |        |     +--ro add-path-id               uint16
+       |        |  +--ro roadm-add-path* [frequency-range-id]
+       |        |     +--ro frequency-range-id        uint16
        |        |     +--ro frequency-range
        |        |     |  +--ro lower-frequency    frequency-thz
        |        |     |  +--ro upper-frequency    frequency-thz
@@ -52,8 +52,8 @@ module: ietf-optical-impairment-topology
        |        |     +--ro roadm-noise-figure?
        |        |             l0-types:decimal-5-or-null
        |        +--:(roadm-drop-path)
-       |           +--ro roadm-drop-path* [drop-path-id]
-       |              +--ro drop-path-id              uint16
+       |           +--ro roadm-drop-path* [frequency-range-id]
+       |              +--ro frequency-range-id        uint16
        |              +--ro frequency-range
        |              |  +--ro lower-frequency    frequency-thz
        |              |  +--ro upper-frequency    frequency-thz
@@ -87,23 +87,27 @@ module: ietf-optical-impairment-topology
              +--ro line-coding-bitrate?                identityref
              +--ro bitrate?                            uint16
              +--ro max-diff-group-delay?               decimal-2
-             +--ro max-chromatic-dispersion?           decimal64
-             +--ro cd-penalty* []
+             +--ro max-chromatic-dispersion?           decimal-2
+             +--ro cd-penalty* [cd-index]
+             |  +--ro cd-index         decimal-2
              |  +--ro cd-value         union
              |  +--ro penalty-value    union
-             +--ro max-polarization-mode-dispersion?   decimal64
-             +--ro pmd-penalty* []
+             +--ro max-polarization-mode-dispersion?   decimal-2
+             +--ro pmd-penalty* [pmd-index]
+             |  +--ro pmd-index        decimal-2
              |  +--ro pmd-value        union
              |  +--ro penalty-value    union
              +--ro max-polarization-dependant-loss
              |       power-loss-or-null
-             +--ro pdl-penalty* []
+             +--ro pdl-penalty* [pdl-index]
+             |  +--ro pdl-index        decimal-2
              |  +--ro pdl-value        power-loss-or-null
              |  +--ro penalty-value    union
              +--ro available-modulation-type?          identityref
              +--ro min-OSNR?                           snr
              +--ro rx-ref-channel-power?               power-dbm
-             +--ro rx-channel-power-penalty* []
+             +--ro rx-channel-power-penalty* [rx-channel-power-index]
+             |  +--ro rx-channel-power-index    decimal-2
              |  +--ro rx-channel-power-value    power-dbm-or-null
              |  +--ro penalty-value             union
              +--ro min-Q-factor?                       decimal-2
@@ -116,7 +120,7 @@ module: ietf-optical-impairment-topology
              +--ro in-band-osnr?                       snr
              +--ro out-of-band-osnr?                   snr
              +--ro tx-polarization-power-difference?   power-ratio
-             +--ro polarization-skew?                  decimal64
+             +--ro polarization-skew?                  decimal-2
   augment /nw:networks/nw:network/nw:node:
     +--rw transponders!
     |  +--ro transponder* [transponder-id]
@@ -249,8 +253,8 @@ module: ietf-optical-impairment-topology
                 |     +--ro type-variety    string
                 |     +--ro operational
                 |        +--ro amplifier-element*
-                |                [amplifier-path-id stage-order]
-                |           +--ro amplifier-path-id
+                |                [frequency-range-id stage-order]
+                |           +--ro frequency-range-id
                 |           |       uint16
                 |           +--ro stage-order
                 |           |       uint8

--- a/ietf-optical-impairment-topology.tree
+++ b/ietf-optical-impairment-topology.tree
@@ -300,15 +300,13 @@ module: ietf-optical-impairment-topology
                 |              |                l0-types:decimal-2-or-null
                 |              +--:(dynamic-gain-equalyzer)
                 |                 +--ro dynamic-gain-equalyzer!
-                |                    +--ro media-channels
-                |                       +--ro media-channel*
-                |                               [flexi-n]
-                |                          +--ro flexi-n
-                |                          |       l0-types:flexi-n
-                |                          +--ro flexi-m?
-                |                          |       l0-types:flexi-m
-                |                          +--ro delta-power?
-                |                                  l0-types:power-ratio-or-null
+                |                    +--ro media-channel* [flexi-n]
+                |                       +--ro flexi-n
+                |                       |       l0-types:flexi-n
+                |                       +--ro flexi-m?
+                |                       |       l0-types:flexi-m
+                |                       +--ro delta-power?
+                |                               l0-types:power-ratio-or-null
                 +--:(fiber)
                 |  +--ro fiber
                 |     +--ro type-variety    string

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -202,7 +202,7 @@ module ietf-optical-impairment-topology {
             mandatory true;
             description
               "Identifies whether the amplifier element is an
-              Optical Amplifier (OA) or a Dynamic Gain Equalyzer
+              Optical Amplifier (OA) or a Dynamic Gain Equalizer
               (DGE).";
             container optical-amplifier {
               description
@@ -293,10 +293,10 @@ module ietf-optical-impairment-topology {
                 }
               }
             }   // container optical-amplifier
-            container dynamic-gain-equalyzer {
+            container dynamic-gain-equalizer {
               presence
                 "When present it indicates that the amplifier element
-                is a Dynamic Gain Equalyzer (DGE)";
+                is a Dynamic Gain Equalizer (DGE)";
               description
                 "The attributes applicable only to DEG amplifier
                 elements.";
@@ -318,7 +318,7 @@ module ietf-optical-impairment-topology {
                     defined for the OMS.";
                 }
               } // media channels list
-            }   // container dynamic-gain-equalyzer
+            }   // container dynamic-gain-equalizer
           } // choice amplifier-element-type
         }  // list amplifier-element
       }  // container operational

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -161,12 +161,16 @@ module ietf-optical-impairment-topology {
               the amplifier is not sufficient to describe the
               amplifier element type.";
           }
+          /* Removed because redundant with the
+             choice amplifier-element-type
+
           leaf is-dynamic-gain-equalyzer {
             type boolean;
             description
               "Indicates whether the amplifier element is a Dynamic 
               Gain Equalizer (DGE).";
           }
+          */
           container frequency-range {
             description
               "The frequency range amplified by the amplifier

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -135,7 +135,7 @@ module ietf-optical-impairment-topology {
           leaf frequency-range-id {
             type uint16;
             description
-              "The identifier of an amplifier path.";
+              "The identifier of the frequency range.";
           }
           leaf stage-order {
             type uint8;
@@ -1001,7 +1001,7 @@ module ietf-optical-impairment-topology {
                 leaf frequency-range-id {
                   type uint16;
                   description
-                    "The identifier of a ROADM express path.";
+                    "The identifier of the frequency range.";
                 }
                 container frequency-range {
                   description
@@ -1024,7 +1024,7 @@ module ietf-optical-impairment-topology {
                 leaf frequency-range-id {
                   type uint16;
                   description
-                    "The identifier of a ROADM add path.";
+                    "The identifier of a frequency range.";
                 }
                 container frequency-range {
                   description
@@ -1047,7 +1047,7 @@ module ietf-optical-impairment-topology {
                 leaf frequency-range-id {
                   type uint16;
                   description
-                    "The identifier of a ROADM drop path.";
+                    "The identifier of a frequency range.";
                 }
                 container frequency-range {
                   description

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -306,25 +306,20 @@ module ietf-optical-impairment-topology {
               description
                 "The attributes applicable only to DEG amplifier
                 elements.";
-              container media-channels {
+              list media-channel {
+                key "flexi-n";
                 description
-                  "The top level container for the list of media
-                  channels.";
-                list media-channel {
-                  key "flexi-n";
+                  "List of media channels represented as (n,m)";
+
+                uses l0-types:flexi-grid-frequency-slot;
+
+                leaf delta-power {
+                  type l0-types:power-ratio-or-null;
                   description
-                    "List of media channels represented as (n,m)";
-
-                  uses l0-types:flexi-grid-frequency-slot;
-
-                  leaf delta-power {
-                    type l0-types:power-ratio-or-null;
-                    description
-                      " Deviation from the reference carrier power 
-                      defined for the OMS.";
-                  }
-                } // media channels list
-              }   // container media-channel-groups
+                    " Deviation from the reference carrier power 
+                    defined for the OMS.";
+                }
+              } // media channels list
             }   // container dynamic-gain-equalyzer
           } // choice amplifier-element-type
         }  // list amplifier-element

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -85,7 +85,7 @@ module ietf-optical-impairment-topology {
 // this note
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2024-02-22 {
+  revision 2024-04-29 {
     description
       "Initial Version";
     reference
@@ -347,10 +347,13 @@ module ietf-optical-impairment-topology {
       }
       leaf total-loss {
         type l0-types:power-loss-or-null;
-        mandatory true ;
         description
-          "includes all losses: fiber loss and conn-in and 
-           conn-out losses";
+          "The measured total loss of the fiber, which includes
+          all possible losses: fiber loss and conn-in and conn-out
+          losses.
+           
+          This attribute is not present when the total loss cannot
+          be measured.";
       }
       leaf pmd {
         type l0-types:decimal-2-or-null;

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -85,7 +85,7 @@ module ietf-optical-impairment-topology {
 // this note
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2024-04-29 {
+  revision 2024-05-20 {
     description
       "Initial Version";
     reference
@@ -125,11 +125,14 @@ module ietf-optical-impairment-topology {
       container operational {
         description "amplifier operational parameters";
         list amplifier-element {
-          key "amplifier-path-id stage-order";
+          key "frequency-range-id stage-order";
           description
             "The list of parallel amplifier elements within an
-            amplifier used to amplify different frequency ranges.";
-          leaf amplifier-path-id {
+            amplifier used to amplify different frequency ranges.
+
+            Two elements in the list must not have the same range
+            or overlapping ranges.";
+          leaf frequency-range-id {
             type uint16;
             description
               "The identifier of an amplifier path.";
@@ -1010,14 +1013,14 @@ module ietf-optical-impairment-topology {
             description "type path impairment";
             case roadm-express-path {
               list roadm-express-path {
-                key express-path-id;
+                key frequency-range-id;
                 description
                   "The list of optical impairments on a ROADM express
                   path for different frequency ranges.
                   
                   Two elements in the list must not have the same
                   range or overlapping ranges.";
-                leaf express-path-id {
+                leaf frequency-range-id {
                   type uint16;
                   description
                     "The identifier of a ROADM express path.";
@@ -1033,14 +1036,14 @@ module ietf-optical-impairment-topology {
             }
             case roadm-add-path {
               list roadm-add-path {
-                key add-path-id;
+                key frequency-range-id;
                 description
                   "The list of optical impairments on a ROADM add
                   path for different frequency ranges.
                   
                   Two elements in the list must not have the same
                   range or overlapping ranges.";
-                leaf add-path-id {
+                leaf frequency-range-id {
                   type uint16;
                   description
                     "The identifier of a ROADM add path.";
@@ -1056,14 +1059,14 @@ module ietf-optical-impairment-topology {
             }          
             case roadm-drop-path {
               list roadm-drop-path {
-                key drop-path-id;
+                key frequency-range-id;
                 description
                   "The list of optical impairments on a ROADM add
                   path for different frequency ranges.
                   
                   Two elements in the list must not have the same
                   range or overlapping ranges.";
-                leaf drop-path-id {
+                leaf frequency-range-id {
                   type uint16;
                   description
                     "The identifier of a ROADM drop path.";

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -85,7 +85,7 @@ module ietf-optical-impairment-topology {
 // this note
 // replace the revision date with the module publication date
 // the format is (year-month-day)
-  revision 2024-05-20 {
+  revision 2024-05-21 {
     description
       "Initial Version";
     reference
@@ -161,16 +161,6 @@ module ietf-optical-impairment-topology {
               the amplifier is not sufficient to describe the
               amplifier element type.";
           }
-          /* Removed because redundant with the
-             choice amplifier-element-type
-
-          leaf is-dynamic-gain-equalyzer {
-            type boolean;
-            description
-              "Indicates whether the amplifier element is a Dynamic 
-              Gain Equalizer (DGE).";
-          }
-          */
           container frequency-range {
             description
               "The frequency range amplified by the amplifier

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -125,9 +125,21 @@ module ietf-optical-impairment-topology {
       container operational {
         description "amplifier operational parameters";
         list amplifier-element {
+          key "amplifier-path-id stage-order";
           description
             "The list of parallel amplifier elements within an
             amplifier used to amplify different frequency ranges.";
+          leaf amplifier-path-id {
+            type uint16;
+            description
+              "The identifier of an amplifier path.";
+          }
+          leaf stage-order {
+            type uint8;
+            description
+              "It allows defining for each spectrum badwidth the
+              cascade order of each amplifier-element.";
+          }
           leaf name {
             type string;
             description
@@ -157,13 +169,6 @@ module ietf-optical-impairment-topology {
               "The frequency range amplified by the amplifier
               element.";
             uses l0-types:frequency-range;
-          }
-          leaf stage-order {
-            type uint8;
-            default 1;
-            description
-              "It allows defining for each spectrum badwidth the
-              cascade order of each amplifier-element.";
           }
           container power-param {
             description
@@ -268,8 +273,15 @@ module ietf-optical-impairment-topology {
                   "The direction of injection of the raman pump.";
               }
               list raman-pump {
+                key pump-id;
                 description
                   "The list of pumps for the Raman amplifier.";
+                leaf pump-id {
+                  type uint16;
+                  description
+                    "The identifier of a pump within an amplifier
+                    element.";
+                }
                 leaf frequency {
                   type l0-types:frequency-thz;
                   description
@@ -296,10 +308,21 @@ module ietf-optical-impairment-topology {
                   "The top level container for the list of media
                   channel groups.";
                 list media-channel-group {
+                  key "otsi-group-ref";
                   description
                     "The list of media channel groups";
+                  leaf otsi-group-ref {
+                    type leafref {
+                      path "../../../../../../../../../../../../" +
+                           "../otsis/otsi-group/otsi-group-id";
+                    }
+                    description
+                      "Reference to the OTSiG to which the OTSis
+                      carried by this media channel group belong
+                      to.";
+                  }
                   list media-channels {
-                    // key "flexi-n";
+                    key "flexi-n";
                     description
                       "List of media channels represented as (n,m)";
 
@@ -743,26 +766,37 @@ module ietf-optical-impairment-topology {
         "The top level container for the list of media channel 
         groups.";
       list media-channel-group {
+        key "otsi-group-ref";
         description
           "The list of media channel groups";
+        leaf otsi-group-ref {
+          type leafref {
+            path "../../../../../../../otsis/" +
+                "otsi-group/otsi-group-id";
+          }
+          description
+            "Reference to the OTSiG to which the OTSis carried by 
+            this media channel group belong to.";
+        }
         list media-channels {
           // key "flexi-n";
+          key "media-channel-id";
           description
             "list of media channels represented as (n,m)";
-
+          leaf media-channel-id {
+            type int16;
+            description
+              "The identifier of media channel within media channel
+              group.
+              
+              It may be equal to the flexi-n attribute, when the
+              flexi-n attribute is present.";
+          }
           // this grouping add both n.m values
           uses l0-types:flexi-grid-frequency-slot;
 
-          leaf otsi-group-ref {
-            type leafref {
-              path "../../../../../../../../otsis/" +
-                  "otsi-group/otsi-group-id";
-            }
-            description
-              "Reference to the OTSiG to which the OTSis carried by 
-              this media channel belong to.";
-          }
           list otsi-ref {
+            key "otsi-carrier-ref";
             description
               "The list of references to the OTSis and their 
               end-to-end Media Channel (e2e-MC) paths within the 
@@ -771,7 +805,7 @@ module ietf-optical-impairment-topology {
               type leafref {
                 path  "../../../../../../../../../otsis/" +
                       "otsi-group[otsi-group-id=current()" +
-                      "/../../otsi-group-ref]/" +
+                      "/../../../otsi-group-ref]/" +
                       "otsi/otsi-carrier-id" ;
               }
               description
@@ -782,7 +816,7 @@ module ietf-optical-impairment-topology {
               type leafref {
                 path  "../../../../../../../../../otsis/" +
                       "otsi-group[otsi-group-id=current()" +
-                      "/../../otsi-group-ref]/" +
+                      "/../../../otsi-group-ref]/" +
                       "otsi[otsi-carrier-id=current()" +
                       "/../otsi-carrier-ref]/e2e-mc-path-id";
               }
@@ -976,12 +1010,18 @@ module ietf-optical-impairment-topology {
             description "type path impairment";
             case roadm-express-path {
               list roadm-express-path {
+                key express-path-id;
                 description
                   "The list of optical impairments on a ROADM express
                   path for different frequency ranges.
                   
                   Two elements in the list must not have the same
                   range or overlapping ranges.";
+                leaf express-path-id {
+                  type uint16;
+                  description
+                    "The identifier of a ROADM express path.";
+                }
                 container frequency-range {
                   description
                     "The frequency range for which these optical
@@ -993,12 +1033,18 @@ module ietf-optical-impairment-topology {
             }
             case roadm-add-path {
               list roadm-add-path {
+                key add-path-id;
                 description
                   "The list of optical impairments on a ROADM add
                   path for different frequency ranges.
                   
                   Two elements in the list must not have the same
                   range or overlapping ranges.";
+                leaf add-path-id {
+                  type uint16;
+                  description
+                    "The identifier of a ROADM add path.";
+                }
                 container frequency-range {
                   description
                     "The frequency range for which these optical
@@ -1010,12 +1056,18 @@ module ietf-optical-impairment-topology {
             }          
             case roadm-drop-path {
               list roadm-drop-path {
+                key drop-path-id;
                 description
                   "The list of optical impairments on a ROADM add
                   path for different frequency ranges.
                   
                   Two elements in the list must not have the same
                   range or overlapping ranges.";
+                leaf drop-path-id {
+                  type uint16;
+                  description
+                    "The identifier of a ROADM drop path.";
+                }
                 container frequency-range {
                   description
                     "The frequency range for which these optical

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -306,40 +306,24 @@ module ietf-optical-impairment-topology {
               description
                 "The attributes applicable only to DEG amplifier
                 elements.";
-              container media-channel-groups {
+              container media-channels {
                 description
                   "The top level container for the list of media
-                  channel groups.";
-                list media-channel-group {
-                  key "otsi-group-ref";
+                  channels.";
+                list media-channel {
+                  key "flexi-n";
                   description
-                    "The list of media channel groups";
-                  leaf otsi-group-ref {
-                    type leafref {
-                      path "../../../../../../../../../../../../" +
-                           "../otsis/otsi-group/otsi-group-id";
-                    }
+                    "List of media channels represented as (n,m)";
+
+                  uses l0-types:flexi-grid-frequency-slot;
+
+                  leaf delta-power {
+                    type l0-types:power-ratio-or-null;
                     description
-                      "Reference to the OTSiG to which the OTSis
-                      carried by this media channel group belong
-                      to.";
+                      " Deviation from the reference carrier power 
+                      defined for the OMS.";
                   }
-                  list media-channels {
-                    key "flexi-n";
-                    description
-                      "List of media channels represented as (n,m)";
-
-                    // this grouping add both n.m values
-                    uses l0-types:flexi-grid-frequency-slot;
-
-                    leaf delta-power {
-                      type l0-types:power-ratio-or-null;
-                      description
-                        " Deviation from the reference carrier power 
-                        defined for the OMS.";
-                    }
-                  } // media channels list
-                } // media-channel-groups list
+                } // media channels list
               }   // container media-channel-groups
             }   // container dynamic-gain-equalyzer
           } // choice amplifier-element-type
@@ -781,9 +765,10 @@ module ietf-optical-impairment-topology {
             "Reference to the OTSiG to which the OTSis carried by 
             this media channel group belong to.";
         }
-        list media-channels {
+        list media-channel {
           // key "flexi-n";
           key "media-channel-id";
+          unique "flexi-n";
           description
             "list of media channels represented as (n,m)";
           leaf media-channel-id {

--- a/ietf-optical-impairment-topology.yang
+++ b/ietf-optical-impairment-topology.yang
@@ -315,7 +315,11 @@ module ietf-optical-impairment-topology {
                 description
                   "List of media channels represented as (n,m)";
 
-                uses l0-types:flexi-grid-frequency-slot;
+                uses l0-types:flexi-grid-frequency-slot {
+                  refine flexi-m {
+                    mandatory true;
+                  }
+                }
 
                 leaf delta-power {
                   type l0-types:power-ratio-or-null;


### PR DESCRIPTION
Updated total-loss attribute: fix #169 
Added keys to the lists: fix #167 and fix #124 

---

Pending merge of https://github.com/ietf-ccamp-wg/ietf-ccamp-layer0-types-ext-RFC9093-bis/pull/100

---

Co-Authored-By: sergio belotti <sergio.belotti@nokia.com>