### PR TITLE
Update draft-ietf-ccamp-optical-impairment-topology-yang.xml

### DIFF
--- a/I-D_in_xml/draft-ietf-ccamp-optical-impairment-topology-yang.xml
+++ b/I-D_in_xml/draft-ietf-ccamp-optical-impairment-topology-yang.xml
@@ -3021,7 +3021,7 @@ module: ietf-optical-impairment-topology
              +--ro pmd-penalty* [pmd-value]
              |  +--ro pmd-value        decimal-2
              |  +--ro penalty-value    union
-             +--ro max-polarization-dependant-loss
+             +--ro max-polarization-dependent-loss
              |       power-loss-or-null
              +--ro pdl-penalty* [pdl-value]
              |  +--ro pdl-value        power-loss


### PR DESCRIPTION
Nit: changing "dependant" to "dependent" as per https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-optical-impairment-topology-yang/blob/ec8b46c313ee83ac4f27e8aa2eff3029cc85e82c/minutes/minute-2024-05-28.md?plain=1#L132